### PR TITLE
Fix: 시큐리티 필터 제외하는 경로를 담은 상수값에 누락된 Swagger 경로 추가

### DIFF
--- a/src/main/java/com/itsuda/perfume/config/SwaggerConfig.java
+++ b/src/main/java/com/itsuda/perfume/config/SwaggerConfig.java
@@ -1,19 +1,38 @@
 package com.itsuda.perfume.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.itsuda.perfume.security.Constants;
+
 @Configuration
 public class SwaggerConfig {
-    
     @Bean
     public OpenAPI openAPI() {
+        // JWT 보안 스키마 설정
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(Constants.AUTHORIZATION_HEADER);  // "Authorization" 헤더 사용
+
+        // API 정보 설정
+        Info info = new Info()
+                .title("Scently API")
+                .description("Scently API 명세서")
+                .version("v1.0.0");
+
         return new OpenAPI()
-                .info(new Info()
-                        .title("Scently API Documentation")
-                        .description("향수 추천 서비스 API 문서")
-                        .version("v1.0.0"));
+                .info(info)
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Authentication", securityScheme));
     }
-} 
+}

--- a/src/main/java/com/itsuda/perfume/controller/AuthController.java
+++ b/src/main/java/com/itsuda/perfume/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.itsuda.perfume.exception.RestApiException;
 import com.itsuda.perfume.security.Constants;
 import com.itsuda.perfume.service.AuthService;
 import com.itsuda.perfume.util.HeaderUtil;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class AuthController {
 
     //소셜 로그인 사용자 정보 등록
     @PatchMapping("/resister")
-    public ResponseDto<?> resister(@UserId Long id, @RequestBody UserResisterDto requestDto) {
+    public ResponseDto<?> resister(@Parameter(hidden = true) @UserId Long id, @RequestBody UserResisterDto requestDto) {
         return new ResponseDto<>(authService.registerUserInfo(id, requestDto));
     }
 }

--- a/src/main/java/com/itsuda/perfume/dto/request/PerfumeRequestDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/request/PerfumeRequestDto.java
@@ -5,6 +5,7 @@ import com.itsuda.perfume.domain.type.CountryType;
 import com.itsuda.perfume.domain.type.GenderType;
 import com.itsuda.perfume.domain.type.PotentialType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,10 +16,21 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PerfumeRequestDto {
+    @Schema(description = "가격", example = "150000", minimum = "0")
     private Integer price;
+
+    @Schema(description = "성별", example = "UNKNOWN", allowableValues = {"MALE", "FEMALE", "UNISEX", "UNKNOWN"})
     private GenderType gender;
+
+    @Schema(description = "향 계열", example = "만다린", examples = {"만다린", "바닐라", "바이올렛", "베르가못", "..."})
     private String accord;
+
+    @Schema(description = "향의 강도", example = "EDT", allowableValues = {"EDP", "EDT", "EDC", "PERFUME"})
     private PotentialType potential;
+
+    @Schema(description = "브랜드", example = "CHANEL", examples = {"CHANEL", "DIOR", "GUCCI", "JO MALONE", "CREED", "BYREDO", "..."})
     private BrandType brand;
+
+    @Schema(description = "원산지", example = "FRANCE", examples = {"FRANCE", "ITALY", "USA", "..."})
     private CountryType country;
 }

--- a/src/main/java/com/itsuda/perfume/dto/request/UserResisterDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/request/UserResisterDto.java
@@ -5,10 +5,17 @@ import com.itsuda.perfume.exception.ErrorCode;
 import com.itsuda.perfume.exception.RestApiException;
 import com.itsuda.perfume.util.ValidationUtil;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserResisterDto(
-        GenderType gender,
-        String birthDate,
-        String nickname
+    @Schema(description = "닉네임", example = "wqew1234")
+    String nickname,
+
+    @Schema(description = "성별", example = "MALE", allowableValues = {"MALE", "FEMALE", "UNKNOWN"})
+    GenderType gender,
+
+    @Schema(description = "생년월일", example = "2000-01-01", pattern = "yyyy-MM-dd")
+    String birthDate 
 ) {
     public UserResisterDto {
         if (!ValidationUtil.isValidDateFormat(birthDate)) {

--- a/src/main/java/com/itsuda/perfume/security/Constants.java
+++ b/src/main/java/com/itsuda/perfume/security/Constants.java
@@ -9,6 +9,7 @@ public class Constants {
             "/oauth2/authorization/kakao", "/login/oauth2/code/kakao",
             "/oauth2/authorization/naver", "/login/oauth2/code/naver",
             "/oauth2/authorization/google", "/login/oauth2/code/google",
-            "/api/auth/reissue"
+            "/api/auth/reissue",
+            "/swagger-ui/**", "/api-docs/**", "/swagger-resources/**", "/webjars/**"
     };
 }

--- a/src/main/java/com/itsuda/perfume/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/itsuda/perfume/security/filter/JwtExceptionFilter.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
@@ -67,8 +68,9 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return Arrays.stream(Constants.NO_NEED_AUTH_URLS).anyMatch(path::startsWith);
+        return Arrays.stream(Constants.NO_NEED_AUTH_URLS)
+                .anyMatch(pattern -> new AntPathMatcher().match(pattern, path));
     }
 }

--- a/src/main/java/com/itsuda/perfume/security/filter/JwtFilter.java
+++ b/src/main/java/com/itsuda/perfume/security/filter/JwtFilter.java
@@ -21,6 +21,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
@@ -70,7 +71,7 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return Arrays.stream(Constants.NO_NEED_AUTH_URLS).anyMatch(path::startsWith);
+        return Arrays.stream(Constants.NO_NEED_AUTH_URLS)
+                .anyMatch(pattern -> new AntPathMatcher().match(pattern, path));
     }
-
 }


### PR DESCRIPTION
## ✨ Description
- 시큐리티 필터에서 인증/인가를 제외할 경로(Constant.NO_AUTH 값에) Swagger와 경로를 누락하여 추가합니다.
- Swagger에서 요청값으로 넘겨줘야할 값들을 클라이언트가 보기 편하게 예시값들을 추가했습니다.
---

## 🔗 Related Issue
- Closes #8 
