### PR TITLE
Fix: 임시 유저가 추가 정보 등록 시 불필요하게 기존 정보와 비교하는 로직 제거

### DIFF
--- a/src/main/java/com/itsuda/perfume/controller/AuthController.java
+++ b/src/main/java/com/itsuda/perfume/controller/AuthController.java
@@ -29,6 +29,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
+    //소셜 로그인 사용자 정보 등록
+    @PatchMapping("/resister")
+    public ResponseDto<?> registerUserInfo(@Parameter(hidden = true) @UserId Long id, @RequestBody UserResisterDto requestDto) {
+        return new ResponseDto<>(authService.registerUserInfo(id, requestDto));
+    }
+
     @PostMapping("/reissue")
     public ResponseDto<JwtTokenDto> reissue(final HttpServletRequest request) {
         final String refreshToken = HeaderUtil.refineHeader(request, Constants.AUTHORIZATION_HEADER, Constants.BEARER_PREFIX)
@@ -36,11 +42,5 @@ public class AuthController {
 
         final JwtTokenDto jwtTokenDto = authService.reissue(refreshToken);
         return new ResponseDto<>(jwtTokenDto);
-    }
-
-    //소셜 로그인 사용자 정보 등록
-    @PatchMapping("/resister")
-    public ResponseDto<?> resister(@Parameter(hidden = true) @UserId Long id, @RequestBody UserResisterDto requestDto) {
-        return new ResponseDto<>(authService.registerUserInfo(id, requestDto));
     }
 }

--- a/src/main/java/com/itsuda/perfume/domain/User.java
+++ b/src/main/java/com/itsuda/perfume/domain/User.java
@@ -90,13 +90,13 @@ public class User {
     }
 
     public void register(GenderType gender, String birthDate, String nickname) {
-        if (nickname != null && (!Objects.equals(this.nickname, nickname))) {
+        if (nickname != null) {
             this.nickname = nickname;
         }
-        if (gender != null && gender != this.gender) {
+        if (gender != null) {
             this.gender = gender;
         }
-        if (birthDate != null && !this.birthDate.equals(birthDate)) {
+        if (birthDate != null) {
             this.birthDate = birthDate;
         }
         this.role = ERole.USER;

--- a/src/main/java/com/itsuda/perfume/security/Constants.java
+++ b/src/main/java/com/itsuda/perfume/security/Constants.java
@@ -6,10 +6,11 @@ public class Constants {
     public static final String BEARER_PREFIX = "Bearer ";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String[] NO_NEED_AUTH_URLS = {
+            "/auth/**",
             "/oauth2/authorization/kakao", "/login/oauth2/code/kakao",
             "/oauth2/authorization/naver", "/login/oauth2/code/naver",
             "/oauth2/authorization/google", "/login/oauth2/code/google",
             "/api/auth/reissue",
-            "/swagger-ui/**", "/api-docs/**", "/swagger-resources/**", "/webjars/**"
+            "/swagger-ui/**", "/api-docs/**", "/swagger-resources/**", "/webjars/**", "/swagger-ui.html"
     };
 }


### PR DESCRIPTION
## ✨ Description
- 임시 유저가 추가 정보 등록 시 불필요하게 기존 정보와 비교하는 로직 제거했습니다
- 추가로, 누락된 Swagger 경로도 추가했습니다

---

## 🔗 Related Issue
- Closes #12 