### PR TITLE
Fix: RefreshToken을 secure cookie로 변경 및 API 연동을 위해 인증/인가 처리 완화

### DIFF
--- a/src/main/java/com/itsuda/perfume/security/Constants.java
+++ b/src/main/java/com/itsuda/perfume/security/Constants.java
@@ -11,6 +11,7 @@ public class Constants {
             "/oauth2/authorization/naver", "/login/oauth2/code/naver",
             "/oauth2/authorization/google", "/login/oauth2/code/google",
             "/api/auth/reissue",
-            "/swagger-ui/**", "/api-docs/**", "/swagger-resources/**", "/webjars/**", "/swagger-ui.html"
+            "/swagger-ui/**", "/api-docs/**", "/swagger-resources/**", "/webjars/**", "/swagger-ui.html",
+            "/api/v1/**"  // 클라이언트 작업 편의를 고려해 모든 API 엔드포인트 허용
     };
 }

--- a/src/main/java/com/itsuda/perfume/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/itsuda/perfume/security/handler/OAuth2LoginSuccessHandler.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -36,9 +37,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         response.setHeader("Pragma", "no-cache");
         response.setHeader("Expires", "0");
 
-        // 프론트 앱뷰 나올때까지 시큐어쿠키가 아닌 일반 쿠키 사용 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-//        CookieUtil.addSecureCookie(response, "refreshToken", jwtTokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
-        CookieUtil.addCookie(response, "refreshToken", jwtTokenDto.getRefreshToken());
+        CookieUtil.addSecureCookie(response, "refreshToken", jwtTokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
         CookieUtil.addCookie(response, "accessToken", jwtTokenDto.getAccessToken());
 
         if (userPrincipal.getRole() == ERole.GUEST) {

--- a/src/main/java/com/itsuda/perfume/util/JwtUtil.java
+++ b/src/main/java/com/itsuda/perfume/util/JwtUtil.java
@@ -56,7 +56,7 @@ public class JwtUtil implements InitializingBean {
     }
 
     public int getWebRefreshTokenExpirationSecond() {
-        return (int) (refreshTokenExpiredPeriod / 1000);
+        return refreshTokenExpiredPeriod;
     }
 
     public JwtTokenDto generateTokens(final Long id, final ERole role) {


### PR DESCRIPTION
## ✨ Description
- RefreshToken을 secure cookie로 변경 및 API 연동을 위해 인증/인가 처리 완화

---

## 🔗 Related Issue
- Closes #25 