### PR TITLE
Fix: CORS 설정 SecurityConfig로 이동

### DIFF
--- a/src/main/java/com/itsuda/perfume/config/SecurityConfig.java
+++ b/src/main/java/com/itsuda/perfume/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import com.itsuda.perfume.security.handler.signout.CustomSignOutProcessHandler;
 import com.itsuda.perfume.security.handler.signout.CustomSignOutResultHandler;
 import com.itsuda.perfume.security.CustomOAuth2UserService;
 import com.itsuda.perfume.util.JwtUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -95,12 +96,16 @@ public class SecurityConfig {
                 .getOrBuild();
     }
 
+    // 안드로이드 앱과의 통신에는 CORS가 필요 없지만, 개발 과정에서 Swagger UI를 통해 API를 테스트하고 문서를 확인하기 위해 CORS 설정 추가
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("https://scently.kro.kr"));
+        configuration.setAllowedOrigins(Arrays.asList(
+            "http://scently.kro.kr:8080",
+            "http://scently.kro.kr"
+        ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
         
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/itsuda/perfume/config/WebMvcConfig.java
+++ b/src/main/java/com/itsuda/perfume/config/WebMvcConfig.java
@@ -5,10 +5,8 @@ import com.itsuda.perfume.intercepter.UserIdInterceptor;
 import com.itsuda.perfume.security.Constants;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -18,25 +16,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
     private final UserIdArgumentResolver userIdArgumentResolver;
-
-
-    // 안드로이드 앱과의 통신에는 CORS가 필요 없지만, 개발 과정에서 Swagger UI를 통해 API를 테스트하고 문서를 확인하기 위해 CORS 설정 추가
-    @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins(
-                            "http://scently.kro.kr:8080",
-                            "http://scently.kro.kr"
-                        )
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true)
-                        .maxAge(3600);
-            }
-        };
-    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {


### PR DESCRIPTION
## ✨ Description
현재 실수로 CORS 설정을 중복해서 설정했는데 이를 SecurityConfig에서만 설정하도록 수정
- Security 필터 체인에서 적절한 CORS 처리 보장
- 인증/인가가 필요한 요청에 대한 preflight 요청 처리 가능
