### PR TITLE
Feat: Social 미구현 API 구현 및 좋아요 기능 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
             git pull origin dev
 
             # Gradle Clean Build
-            ./gradlew clean build
+            ./gradlew clean build -x test
 
             # 기존 애플리케이션 종료
             sudo fuser -k -n tcp 8080 || true

--- a/src/main/java/com/itsuda/perfume/annotation/UserId.java
+++ b/src/main/java/com/itsuda/perfume/annotation/UserId.java
@@ -12,4 +12,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME) //런타임까지 어노테이션 정보를 유지
 @Target(ElementType.PARAMETER) //파라미터에만 적용
 public @interface UserId {
+    boolean required() default true;
 }

--- a/src/main/java/com/itsuda/perfume/controller/FcmController.java
+++ b/src/main/java/com/itsuda/perfume/controller/FcmController.java
@@ -1,5 +1,6 @@
 package com.itsuda.perfume.controller;
 
+import com.itsuda.perfume.annotation.UserId;
 import com.itsuda.perfume.dto.request.fcm.FcmTokenRequestDto;
 import com.itsuda.perfume.exception.ResponseDto;
 import com.itsuda.perfume.service.FcmService;
@@ -24,8 +25,10 @@ public class FcmController {
 
     @Operation(summary = "FCM 토큰 등록", description = "사용자의 FCM 토큰을 등록합니다.")
     @PutMapping("/token")
-    public ResponseDto<Map<String, Boolean>> saveUserFcmToken(@Valid @RequestBody FcmTokenRequestDto fcmTokenRequestDto) {
-        fcmService.saveUserFcmToken(0L, fcmTokenRequestDto.fcmToken());
+    public ResponseDto<Map<String, Boolean>> saveUserFcmToken(
+            @UserId Long userId,
+            @Valid @RequestBody FcmTokenRequestDto fcmTokenRequestDto) {
+        fcmService.saveUserFcmToken(userId, fcmTokenRequestDto.fcmToken());
         return new ResponseDto<>(Map.of("isSaved", Boolean.TRUE));
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -8,9 +8,7 @@ import com.itsuda.perfume.dto.request.ootd.OotdCommentRequestDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
 import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
-import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
-import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.exception.ResponseDto;
@@ -73,8 +71,9 @@ public class OotdController {
 
     @Operation(summary = "OOTD 좋아요", description = "OOTD 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/like")
-    public ResponseDto<OotdLikeDto> likeOotdByOotdId(@UserId Long userId, @PathVariable Long ootdId) {
-        return new ResponseDto<>(ootdService.sendLikeToOotd(ootdId, userId));
+    public ResponseDto<Void> likeOotdByOotdId(@UserId Long userId, @PathVariable Long ootdId) {
+        ootdService.sendLikeToOotd(ootdId, userId);
+        return new ResponseDto<>(null);
     }
 
     @Operation(summary = "OOTD 상세 댓글 조회", description = "OOTD 게시글 ID에 맞는 댓글들을 조회합니다.")
@@ -94,8 +93,8 @@ public class OotdController {
 
     @Operation(summary = "OOTD 댓글 좋아요", description = "OOTD 게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/comments/{commentId}/like")
-    public ResponseDto<OotdCommentLikeDto> likeOotdCommentByCommentId(@UserId Long userId,
-                                                                      @PathVariable Long commentId) {
-        return new ResponseDto<>(ootdService.sendLikeToOotdComment(userId, commentId));
+    public ResponseDto<Void> likeOotdCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
+        ootdService.sendLikeToOotdComment(userId, commentId);
+        return new ResponseDto<>(null);
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -1,5 +1,6 @@
 package com.itsuda.perfume.controller;
 
+import com.itsuda.perfume.annotation.UserId;
 import com.itsuda.perfume.domain.type.OotdOrderType;
 import com.itsuda.perfume.dto.request.ootd.CreateOotdDto;
 import com.itsuda.perfume.dto.request.ootd.ImageFilesDto;
@@ -42,16 +43,18 @@ public class OotdController {
     @Operation(summary = "OOTD 게시글 목록 조회", description = "OOTD 게시글들을 정렬 순서에 맞게 조회합니다.")
     @GetMapping
     public ResponseDto<OotdMainDto> getOotdThumbnails(
+            @UserId(required = false) Long userId,
             @RequestParam(required = false, defaultValue = "NEWEST") OotdOrderType order,
             @RequestParam int page, @RequestParam int size) {
-        return new ResponseDto<>(ootdService.getOotdThumbnailsByOrderType(page, size, order, 0L));
+        return new ResponseDto<>(ootdService.getOotdThumbnailsByOrderType(page, size, order, userId));
     }
 
     @Operation(summary = "OOTD 작성", description = "OOTD 게시판에 게시글을 작성합니다.")
     @PostMapping
-    public ResponseDto<CreatedOotdDto> createOotd(@Valid @RequestPart CreateOotdDto createOotdDto,
+    public ResponseDto<CreatedOotdDto> createOotd(@UserId Long userId,
+                                                  @Valid @RequestPart CreateOotdDto createOotdDto,
                                                   @Valid @ModelAttribute ImageFilesDto imageFilesDto) {
-        return new ResponseDto<>(ootdService.createOotd(0L, createOotdDto.content(), createOotdDto.tagNames(),
+        return new ResponseDto<>(ootdService.createOotd(userId, createOotdDto.content(), createOotdDto.tagNames(),
                 createOotdDto.volume(), createOotdDto.perfumeIds(), imageFilesDto.images()));
     }
 
@@ -63,14 +66,15 @@ public class OotdController {
 
     @Operation(summary = "OOTD 게시글 상세 조회", description = "OOTD 게시글 ID에 맞는 게시글을 상세하게 조회합니다.")
     @GetMapping("/{ootdId}")
-    public ResponseDto<OotdDetailDto> getOotdDetailByOotdID(@PathVariable Long ootdId) {
-        return new ResponseDto<>(ootdService.getOotdDetailByOotdId(ootdId, 0L));
+    public ResponseDto<OotdDetailDto> getOotdDetailByOotdID(@UserId(required = false) Long userId,
+                                                            @PathVariable Long ootdId) {
+        return new ResponseDto<>(ootdService.getOotdDetailByOotdId(ootdId, userId));
     }
 
     @Operation(summary = "OOTD 게시글 좋아요 오청", description = "OOTD 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/like")
-    public ResponseDto<OotdLikeDto> likeOotdByOotdId(@PathVariable Long ootdId) {
-        return new ResponseDto<>(ootdService.sendLikeToOotd(ootdId, 0L));
+    public ResponseDto<OotdLikeDto> likeOotdByOotdId(@UserId Long userId, @PathVariable Long ootdId) {
+        return new ResponseDto<>(ootdService.sendLikeToOotd(ootdId, userId));
     }
 
     @Operation(summary = "게시글 상세 댓글 조회", description = "OOTD 게시글 ID에 맞는 댓글들을 조회합니다.")
@@ -82,14 +86,16 @@ public class OotdController {
     @Operation(summary = "게시글 댓글 추가", description = "OOTD 게시글에 댓글을 답니다.")
     @PostMapping("/{ootdId}/comments")
     public ResponseDto<OotdCommentDto> writeComment(
+            @UserId Long userId,
             @PathVariable Long ootdId, @Validated @RequestBody OotdCommentRequestDto postComment) {
-        return new ResponseDto<>(ootdService.writeCommentToOotd(ootdId, 0L,
+        return new ResponseDto<>(ootdService.writeCommentToOotd(ootdId, userId,
                 postComment.commentId(), postComment.comment()));
     }
 
     @Operation(summary = "게시글 댓글 좋아요 요청", description = "OOTD 게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/comments/{commentId}/like")
-    public ResponseDto<OotdCommentLikeDto> likeOotdCommentByCommentId(@PathVariable Long commentId) {
-        return new ResponseDto<>(ootdService.sendLikeToOotdComment(0L, commentId));
+    public ResponseDto<OotdCommentLikeDto> likeOotdCommentByCommentId(@UserId Long userId,
+                                                                      @PathVariable Long commentId) {
+        return new ResponseDto<>(ootdService.sendLikeToOotdComment(userId, commentId));
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -11,8 +11,10 @@ import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
+import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.exception.ResponseDto;
 import com.itsuda.perfume.service.OotdService;
+import com.itsuda.perfume.service.PerfumeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -35,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OotdController {
 
     private final OotdService ootdService;
+    private final PerfumeService perfumeService;
 
     @Operation(summary = "OOTD 게시글 목록 조회", description = "OOTD 게시글들을 정렬 순서에 맞게 조회합니다.")
     @GetMapping
@@ -44,12 +47,18 @@ public class OotdController {
         return new ResponseDto<>(ootdService.getOotdThumbnailsByOrderType(page, size, order, 0L));
     }
 
-    @PostMapping
     @Operation(summary = "OOTD 작성", description = "OOTD 게시판에 게시글을 작성합니다.")
+    @PostMapping
     public ResponseDto<CreatedOotdDto> createOotd(@Valid @RequestPart CreateOotdDto createOotdDto,
                                                   @Valid @ModelAttribute ImageFilesDto imageFilesDto) {
         return new ResponseDto<>(ootdService.createOotd(0L, createOotdDto.content(), createOotdDto.tagNames(),
                 createOotdDto.volume(), createOotdDto.perfumeId(), imageFilesDto.images()));
+    }
+
+    @Operation(summary = "OOTD 향수 조회", description = "OOTD 작성 중 모든 향수 목록을 조회합니다.")
+    @GetMapping("/perfumes")
+    public ResponseDto<OotdPerfumesDto> getOotdPerfumes() {
+        return new ResponseDto<>(perfumeService.getAllPerfumes());
     }
 
     @Operation(summary = "OOTD 게시글 상세 조회", description = "OOTD 게시글 ID에 맞는 게시글을 상세하게 조회합니다.")

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -7,6 +7,7 @@ import com.itsuda.perfume.dto.request.ootd.OotdCommentRequestDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
 import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
+import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
@@ -63,17 +64,23 @@ public class OotdController {
         return new ResponseDto<>(ootdService.sendLikeToOotd(ootdId, 0L));
     }
 
-    @GetMapping("/{ootdId}/comments")
     @Operation(summary = "게시글 상세 댓글 조회", description = "OOTD 게시글 ID에 맞는 댓글들을 조회합니다.")
+    @GetMapping("/{ootdId}/comments")
     public ResponseDto<CommentsDto> getComments(@PathVariable Long ootdId) {
         return new ResponseDto<>(ootdService.getCommentsByOotdId(ootdId));
     }
 
-    @PostMapping("/{ootdId}/comments")
     @Operation(summary = "게시글 댓글 추가", description = "OOTD 게시글에 댓글을 답니다.")
+    @PostMapping("/{ootdId}/comments")
     public ResponseDto<OotdCommentDto> writeComment(
             @PathVariable Long ootdId, @Validated @RequestBody OotdCommentRequestDto postComment) {
         return new ResponseDto<>(ootdService.writeCommentToOotd(ootdId, 0L,
                 postComment.commentId(), postComment.comment()));
+    }
+
+    @Operation(summary = "게시글 댓글 좋아요 요청", description = "OOTD 게시글의 댓글에 좋아요를 요청합니다.")
+    @PostMapping("/{ootdId}/comments/{commentId}/like")
+    public ResponseDto<OotdCommentLikeDto> likeOotdCommentByCommentId(@PathVariable Long commentId) {
+        return new ResponseDto<>(ootdService.sendLikeToOotdComment(0L, commentId));
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -52,7 +52,7 @@ public class OotdController {
     public ResponseDto<CreatedOotdDto> createOotd(@Valid @RequestPart CreateOotdDto createOotdDto,
                                                   @Valid @ModelAttribute ImageFilesDto imageFilesDto) {
         return new ResponseDto<>(ootdService.createOotd(0L, createOotdDto.content(), createOotdDto.tagNames(),
-                createOotdDto.volume(), createOotdDto.perfumeId(), imageFilesDto.images()));
+                createOotdDto.volume(), createOotdDto.perfumeIds(), imageFilesDto.images()));
     }
 
     @Operation(summary = "OOTD 향수 조회", description = "OOTD 작성 중 모든 향수 목록을 조회합니다.")

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -40,7 +40,7 @@ public class OotdController {
     private final OotdService ootdService;
     private final PerfumeService perfumeService;
 
-    @Operation(summary = "OOTD 게시글 목록 조회", description = "OOTD 게시글들을 정렬 순서에 맞게 조회합니다.")
+    @Operation(summary = "OOTD 목록 조회", description = "OOTD들을 정렬 순서에 맞게 조회합니다.")
     @GetMapping
     public ResponseDto<OotdMainDto> getOotdThumbnails(
             @UserId(required = false) Long userId,
@@ -49,7 +49,7 @@ public class OotdController {
         return new ResponseDto<>(ootdService.getOotdThumbnailsByOrderType(page, size, order, userId));
     }
 
-    @Operation(summary = "OOTD 작성", description = "OOTD 게시판에 게시글을 작성합니다.")
+    @Operation(summary = "OOTD 작성", description = "OOTD에 게시글을 작성합니다.")
     @PostMapping
     public ResponseDto<CreatedOotdDto> createOotd(@UserId Long userId,
                                                   @Valid @RequestPart CreateOotdDto createOotdDto,
@@ -64,26 +64,26 @@ public class OotdController {
         return new ResponseDto<>(perfumeService.getAllPerfumes());
     }
 
-    @Operation(summary = "OOTD 게시글 상세 조회", description = "OOTD 게시글 ID에 맞는 게시글을 상세하게 조회합니다.")
+    @Operation(summary = "OOTD 상세 조회", description = "OOTD ID에 맞는 게시글을 상세하게 조회합니다.")
     @GetMapping("/{ootdId}")
     public ResponseDto<OotdDetailDto> getOotdDetailByOotdID(@UserId(required = false) Long userId,
                                                             @PathVariable Long ootdId) {
         return new ResponseDto<>(ootdService.getOotdDetailByOotdId(ootdId, userId));
     }
 
-    @Operation(summary = "OOTD 게시글 좋아요 오청", description = "OOTD 게시글에 좋아요를 요청합니다.")
+    @Operation(summary = "OOTD 좋아요", description = "OOTD 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/like")
     public ResponseDto<OotdLikeDto> likeOotdByOotdId(@UserId Long userId, @PathVariable Long ootdId) {
         return new ResponseDto<>(ootdService.sendLikeToOotd(ootdId, userId));
     }
 
-    @Operation(summary = "게시글 상세 댓글 조회", description = "OOTD 게시글 ID에 맞는 댓글들을 조회합니다.")
+    @Operation(summary = "OOTD 상세 댓글 조회", description = "OOTD 게시글 ID에 맞는 댓글들을 조회합니다.")
     @GetMapping("/{ootdId}/comments")
     public ResponseDto<CommentsDto> getComments(@PathVariable Long ootdId) {
         return new ResponseDto<>(ootdService.getCommentsByOotdId(ootdId));
     }
 
-    @Operation(summary = "게시글 댓글 추가", description = "OOTD 게시글에 댓글을 답니다.")
+    @Operation(summary = "OOTD 댓글 작성", description = "OOTD 게시글에 댓글을 답니다.")
     @PostMapping("/{ootdId}/comments")
     public ResponseDto<OotdCommentDto> writeComment(
             @UserId Long userId,
@@ -92,7 +92,7 @@ public class OotdController {
                 postComment.commentId(), postComment.comment()));
     }
 
-    @Operation(summary = "게시글 댓글 좋아요 요청", description = "OOTD 게시글의 댓글에 좋아요를 요청합니다.")
+    @Operation(summary = "OOTD 댓글 좋아요", description = "OOTD 게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/comments/{commentId}/like")
     public ResponseDto<OotdCommentLikeDto> likeOotdCommentByCommentId(@UserId Long userId,
                                                                       @PathVariable Long commentId) {

--- a/src/main/java/com/itsuda/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PerfumeController.java
@@ -1,5 +1,6 @@
 package com.itsuda.perfume.controller;
 
+import com.itsuda.perfume.annotation.UserId;
 import com.itsuda.perfume.dto.request.PerfumeRequestDto;
 import com.itsuda.perfume.dto.response.PerfumeAccordDto;
 import com.itsuda.perfume.dto.response.PerfumeDetailDto;
@@ -13,6 +14,8 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +47,12 @@ public class PerfumeController {
     @GetMapping("/{perfumeId}")
     public ResponseDto<PerfumeDetailDto> getPerfumeDetail(@RequestParam Long perfumeId) {
         return new ResponseDto<>(perfumeService.getPerfumeDetail(perfumeId));
+    }
+
+    @Operation(summary = "향수 위시 담기", description = "향수를 위시에 담습니다.")
+    @PostMapping("/{perfumeId}/like")
+    public ResponseDto<Void> wishPerfume(@PathVariable Long perfumeId, @UserId Long userId) {
+        perfumeService.sendWishToPerfume(perfumeId, userId);
+        return new ResponseDto<>(null);
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/PostController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PostController.java
@@ -6,6 +6,7 @@ import com.itsuda.perfume.dto.request.post.PostCommentRequestDto;
 import com.itsuda.perfume.dto.response.post.CommentsDto;
 import com.itsuda.perfume.dto.response.post.CreatedPostDto;
 import com.itsuda.perfume.dto.response.post.PostCommentDto;
+import com.itsuda.perfume.dto.response.post.PostCommentLikeDto;
 import com.itsuda.perfume.dto.response.post.PostDetailDto;
 import com.itsuda.perfume.dto.response.post.PostLikeDto;
 import com.itsuda.perfume.dto.response.post.PostMainDto;
@@ -71,5 +72,11 @@ public class PostController {
             @PathVariable Long postId, @Validated @RequestBody PostCommentRequestDto postComment) {
         return new ResponseDto<>(postService.writeCommentToPost(postId, 0L,
                 postComment.commentId(), postComment.comment()));
+    }
+
+    @Operation(summary = "게시글 댓글 좋아요 요청", description = "자유게시글의 댓글에 좋아요를 요청합니다.")
+    @PostMapping("/{postId}/comments/{commentId}/like")
+    public ResponseDto<PostCommentLikeDto> likePostCommentByCommentId(@PathVariable Long commentId) {
+        return new ResponseDto<>(postService.sendLikeToPostComment(0L, commentId));
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/PostController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.itsuda.perfume.controller;
 
+import com.itsuda.perfume.annotation.UserId;
 import com.itsuda.perfume.domain.type.PostOrderType;
 import com.itsuda.perfume.dto.request.post.CreatePostDto;
 import com.itsuda.perfume.dto.request.post.PostCommentRequestDto;
@@ -16,7 +17,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,9 +43,11 @@ public class PostController {
 
     @PostMapping
     @Operation(summary = "게시글 작성", description = "자유게시판에 게시글을 작성합니다.")
-    public ResponseDto<CreatedPostDto> createPost(@Valid @RequestBody CreatePostDto createPostDto) {
+    public ResponseDto<CreatedPostDto> createPost(
+            @UserId Long userId,
+            @Valid @RequestBody CreatePostDto createPostDto) {
         return new ResponseDto<>(postService.createPost(
-                0L, createPostDto.title(), createPostDto.content(), createPostDto.tagNames()));
+                userId, createPostDto.title(), createPostDto.content(), createPostDto.tagNames()));
     }
 
     @GetMapping("/{postId}")
@@ -56,8 +58,8 @@ public class PostController {
 
     @Operation(summary = "자유게시판 게시글 좋아요 오청", description = "자유게시판 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/like")
-    public ResponseDto<PostLikeDto> likePostByPostId(@PathVariable Long postId) {
-        return new ResponseDto<>(postService.sendLikeToPost(postId, 0L));
+    public ResponseDto<PostLikeDto> likePostByPostId(@UserId Long userId, @PathVariable Long postId) {
+        return new ResponseDto<>(postService.sendLikeToPost(postId, userId));
     }
 
     @GetMapping("/{postId}/comments")
@@ -69,14 +71,14 @@ public class PostController {
     @PostMapping("/{postId}/comments")
     @Operation(summary = "게시글 댓글 추가", description = "자유게시판의 게시글에 댓글을 답니다.")
     public ResponseDto<PostCommentDto> writeComment(
-            @PathVariable Long postId, @Validated @RequestBody PostCommentRequestDto postComment) {
-        return new ResponseDto<>(postService.writeCommentToPost(postId, 0L,
+            @UserId Long userId, @PathVariable Long postId, @Valid @RequestBody PostCommentRequestDto postComment) {
+        return new ResponseDto<>(postService.writeCommentToPost(postId, userId,
                 postComment.commentId(), postComment.comment()));
     }
 
     @Operation(summary = "게시글 댓글 좋아요 요청", description = "자유게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/comments/{commentId}/like")
-    public ResponseDto<PostCommentLikeDto> likePostCommentByCommentId(@PathVariable Long commentId) {
-        return new ResponseDto<>(postService.sendLikeToPostComment(0L, commentId));
+    public ResponseDto<PostCommentLikeDto> likePostCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
+        return new ResponseDto<>(postService.sendLikeToPostComment(userId, commentId));
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/PostController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PostController.java
@@ -33,16 +33,16 @@ public class PostController {
 
     private final PostService postService;
 
+    @Operation(summary = "자유게시글 목록 조회", description = "자유게시판에 올라온 게시글들을 조회합니다.")
     @GetMapping
-    @Operation(summary = "게시글 목록 조회", description = "자유게시판에 올라온 게시글들을 조회합니다.")
     public ResponseDto<PostMainDto> getPosts(
             @RequestParam(required = false, defaultValue = "NEWEST") PostOrderType order,
             @RequestParam int page, @RequestParam int size) {
         return new ResponseDto<>(postService.getPostsByOrderType(page, size, order));
     }
 
+    @Operation(summary = "자유게시글 작성", description = "자유게시판에 게시글을 작성합니다.")
     @PostMapping
-    @Operation(summary = "게시글 작성", description = "자유게시판에 게시글을 작성합니다.")
     public ResponseDto<CreatedPostDto> createPost(
             @UserId Long userId,
             @Valid @RequestBody CreatePostDto createPostDto) {
@@ -50,33 +50,33 @@ public class PostController {
                 userId, createPostDto.title(), createPostDto.content(), createPostDto.tagNames()));
     }
 
+    @Operation(summary = "자유게시글 상세 조회", description = "자유게시판에서 게시글 ID에 맞는 게시글을 조회합니다.")
     @GetMapping("/{postId}")
-    @Operation(summary = "게시글 상세 조회", description = "자유게시판에서 게시글 ID에 맞는 게시글을 조회합니다.")
     public ResponseDto<PostDetailDto> getPostDetail(@PathVariable Long postId) {
         return new ResponseDto<>(postService.getPostDetailByPostId(postId));
     }
 
-    @Operation(summary = "자유게시판 게시글 좋아요 오청", description = "자유게시판 게시글에 좋아요를 요청합니다.")
+    @Operation(summary = "자유게시글 좋아요", description = "자유게시판 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/like")
     public ResponseDto<PostLikeDto> likePostByPostId(@UserId Long userId, @PathVariable Long postId) {
         return new ResponseDto<>(postService.sendLikeToPost(postId, userId));
     }
 
+    @Operation(summary = "자유게시글 상세 댓글 조회", description = "자유게시판에서 게시글 ID에 맞는 댓글들을 조회합니다.")
     @GetMapping("/{postId}/comments")
-    @Operation(summary = "게시글 상세 댓글 조회", description = "자유게시판에서 게시글 ID에 맞는 댓글들을 조회합니다.")
     public ResponseDto<CommentsDto> getComments(@PathVariable Long postId) {
         return new ResponseDto<>(postService.getCommentsByPostId(postId));
     }
 
+    @Operation(summary = "자유게시글 댓글 작성", description = "자유게시판의 게시글에 댓글을 답니다.")
     @PostMapping("/{postId}/comments")
-    @Operation(summary = "게시글 댓글 추가", description = "자유게시판의 게시글에 댓글을 답니다.")
     public ResponseDto<PostCommentDto> writeComment(
             @UserId Long userId, @PathVariable Long postId, @Valid @RequestBody PostCommentRequestDto postComment) {
         return new ResponseDto<>(postService.writeCommentToPost(postId, userId,
                 postComment.commentId(), postComment.comment()));
     }
 
-    @Operation(summary = "게시글 댓글 좋아요 요청", description = "자유게시글의 댓글에 좋아요를 요청합니다.")
+    @Operation(summary = "자유게시글 댓글 좋아요", description = "자유게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/comments/{commentId}/like")
     public ResponseDto<PostCommentLikeDto> likePostCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
         return new ResponseDto<>(postService.sendLikeToPostComment(userId, commentId));

--- a/src/main/java/com/itsuda/perfume/controller/PostController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PostController.java
@@ -7,9 +7,7 @@ import com.itsuda.perfume.dto.request.post.PostCommentRequestDto;
 import com.itsuda.perfume.dto.response.post.CommentsDto;
 import com.itsuda.perfume.dto.response.post.CreatedPostDto;
 import com.itsuda.perfume.dto.response.post.PostCommentDto;
-import com.itsuda.perfume.dto.response.post.PostCommentLikeDto;
 import com.itsuda.perfume.dto.response.post.PostDetailDto;
-import com.itsuda.perfume.dto.response.post.PostLikeDto;
 import com.itsuda.perfume.dto.response.post.PostMainDto;
 import com.itsuda.perfume.exception.ResponseDto;
 import com.itsuda.perfume.service.PostService;
@@ -58,8 +56,9 @@ public class PostController {
 
     @Operation(summary = "자유게시글 좋아요", description = "자유게시판 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/like")
-    public ResponseDto<PostLikeDto> likePostByPostId(@UserId Long userId, @PathVariable Long postId) {
-        return new ResponseDto<>(postService.sendLikeToPost(postId, userId));
+    public ResponseDto<Void> likePostByPostId(@UserId Long userId, @PathVariable Long postId) {
+        postService.sendLikeToPost(postId, userId);
+        return new ResponseDto<>(null);
     }
 
     @Operation(summary = "자유게시글 상세 댓글 조회", description = "자유게시판에서 게시글 ID에 맞는 댓글들을 조회합니다.")
@@ -78,7 +77,8 @@ public class PostController {
 
     @Operation(summary = "자유게시글 댓글 좋아요", description = "자유게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/comments/{commentId}/like")
-    public ResponseDto<PostCommentLikeDto> likePostCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
-        return new ResponseDto<>(postService.sendLikeToPostComment(userId, commentId));
+    public ResponseDto<Void> likePostCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
+        postService.sendLikeToPostComment(userId, commentId);
+        return new ResponseDto<>(null);
     }
 }

--- a/src/main/java/com/itsuda/perfume/domain/Comment.java
+++ b/src/main/java/com/itsuda/perfume/domain/Comment.java
@@ -59,4 +59,12 @@ public class Comment extends ModifiableBaseEntity {
         this.post = post;
         this.user = user;
     }
+
+    public int increaseLikeCount() {
+        return ++this.likeCount;
+    }
+
+    public int decreaseLikeCount() {
+        return --this.likeCount;
+    }
 }

--- a/src/main/java/com/itsuda/perfume/domain/Ootd.java
+++ b/src/main/java/com/itsuda/perfume/domain/Ootd.java
@@ -49,10 +49,6 @@ public class Ootd extends ModifiableBaseEntity {
     @OneToMany(mappedBy = "ootd", fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
-    @ManyToOne
-    @JoinColumn(name = "perfume_id", nullable = false)
-    private Perfume perfume;
-
     @OneToMany(mappedBy = "ootd", fetch = FetchType.LAZY)
     private List<OotdTag> ootdTags = new ArrayList<>();
 
@@ -61,11 +57,10 @@ public class Ootd extends ModifiableBaseEntity {
     private User user;
 
     @Builder
-    private Ootd(int likeCount, int volume, String content, Perfume perfume, User user) {
+    private Ootd(int likeCount, int volume, String content, User user) {
         this.likeCount = likeCount;
         this.volume = volume;
         this.content = content;
-        this.perfume = perfume;
         this.user = user;
     }
 

--- a/src/main/java/com/itsuda/perfume/domain/OotdPerfume.java
+++ b/src/main/java/com/itsuda/perfume/domain/OotdPerfume.java
@@ -1,0 +1,37 @@
+package com.itsuda.perfume.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OotdPerfume {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ootd_id", nullable = false)
+    private Ootd ootd;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "perfume_id", nullable = false)
+    private Perfume perfume;
+
+    @Builder
+    private OotdPerfume(Ootd ootd, Perfume perfume) {
+        this.ootd = ootd;
+        this.perfume = perfume;
+    }
+}

--- a/src/main/java/com/itsuda/perfume/domain/Perfume.java
+++ b/src/main/java/com/itsuda/perfume/domain/Perfume.java
@@ -1,18 +1,26 @@
 package com.itsuda.perfume.domain;
 
-import jakarta.persistence.*;
+import com.itsuda.perfume.domain.type.BrandType;
+import com.itsuda.perfume.domain.type.CountryType;
+import com.itsuda.perfume.domain.type.GenderType;
+import com.itsuda.perfume.domain.type.PotentialType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.itsuda.perfume.domain.type.GenderType;
-import com.itsuda.perfume.domain.type.BrandType;
-import com.itsuda.perfume.domain.type.CountryType;
-import com.itsuda.perfume.domain.type.PotentialType;
 
 @Entity
 @Getter
@@ -21,48 +29,52 @@ public class Perfume {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     private String name;
 
     private String imageUri;
-    
+
     @Enumerated(EnumType.STRING)
     private GenderType gender;
-    
+
     @Enumerated(EnumType.STRING)
     private BrandType brand;
-    
+
     @Enumerated(EnumType.STRING)
     private CountryType country;
-    
+
     @Enumerated(EnumType.STRING)
     private PotentialType potential;
-    
+
     private String description; // 향 한줄 소개
-    
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private int wishCount;
+
     @Column(name = "registered_at")
     private LocalDate registeredAt;
 
     // ------------------------ 관계 설정 ----------------------------
-    
+
     @OneToMany(mappedBy = "perfume")
     private List<Review> reviews = new ArrayList<>();
-    
+
     @OneToMany(mappedBy = "perfume")
     private List<WishPerfume> wishPerfumes = new ArrayList<>();
-    
+
     @OneToMany(mappedBy = "perfume")
     private List<PerfumeAccord> perfumeAccords = new ArrayList<>();
-    
+
     @OneToMany(mappedBy = "perfume")
     private List<PerfumeVolume> perfumeVolumes = new ArrayList<>();
-    
+
     @OneToMany(mappedBy = "perfume")
     private List<PerfumeDetail> details = new ArrayList<>();
 
     @Builder
     private Perfume(String name, String imageUri, GenderType gender, BrandType brand, CountryType country,
-                   PotentialType potential, String description, LocalDate registeredAt) {
+                    PotentialType potential, String description, LocalDate registeredAt) {
         this.name = name;
         this.imageUri = imageUri;
         this.gender = gender;
@@ -71,6 +83,14 @@ public class Perfume {
         this.potential = potential;
         this.description = description;
         this.registeredAt = registeredAt;
+    }
+
+    public int increaseLikeCount() {
+        return ++this.wishCount;
+    }
+
+    public int decreaseLikeCount() {
+        return --this.wishCount;
     }
 }
 

--- a/src/main/java/com/itsuda/perfume/domain/UserLikeComment.java
+++ b/src/main/java/com/itsuda/perfume/domain/UserLikeComment.java
@@ -1,0 +1,37 @@
+package com.itsuda.perfume.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserLikeComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Builder
+    private UserLikeComment(User user, Comment comment) {
+        this.user = user;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/itsuda/perfume/domain/WishPerfume.java
+++ b/src/main/java/com/itsuda/perfume/domain/WishPerfume.java
@@ -1,32 +1,44 @@
 package com.itsuda.perfume.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WishPerfume {
+public class WishPerfume extends ModifiableBaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "perfume_id")
     private Perfume perfume;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "customer_id")
     private User customer;
-    
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-    
-    @Column(name = "modified_at")
-    private LocalDateTime modifiedAt;
-    
-    private String status;
-} 
+
+    @ColumnDefault("true")
+    private boolean isWished = true;
+
+    @Builder
+    private WishPerfume(Perfume perfume, User customer) {
+        this.perfume = perfume;
+        this.customer = customer;
+    }
+
+    public boolean changeWishStatus() {
+        return isWished = !isWished;
+    }
+}

--- a/src/main/java/com/itsuda/perfume/dto/request/ootd/CreateOotdDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/request/ootd/CreateOotdDto.java
@@ -19,8 +19,9 @@ public record CreateOotdDto(
         int volume,
 
         @NotNull
-        @Schema(description = "향수 아이디", example = "1")
-        Long perfumeId,
+        @Size(min = 1, max = 3, message="INVALID_PERFUME_LIST")
+        @Schema(description = "향수 아이디", example = "[1, 2, 3...]", minimum = "1", maximum = "3")
+        List<Long> perfumeIds,
 
         @ValidTag
         @Size(max = 10, message = "MAX_TAG_SIZE")

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdCommentLikeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdCommentLikeDto.java
@@ -1,0 +1,7 @@
+package com.itsuda.perfume.dto.response.ootd;
+
+public record OotdCommentLikeDto(
+        Boolean isLiked,
+        int likeCount
+) {
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdCommentLikeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdCommentLikeDto.java
@@ -1,7 +1,0 @@
-package com.itsuda.perfume.dto.response.ootd;
-
-public record OotdCommentLikeDto(
-        Boolean isLiked,
-        int likeCount
-) {
-}

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdDetailDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdDetailDto.java
@@ -4,13 +4,16 @@ import com.itsuda.perfume.domain.Ootd;
 import com.itsuda.perfume.domain.Perfume;
 import com.itsuda.perfume.domain.User;
 
+import java.util.List;
+
 public record OotdDetailDto(
         OotdInfoDto ootdInfo,
         UserInfoDto userInfo,
-        PerfumeInfoDto perfumeInfoDto
+        List<PerfumeInfoDto> perfumeInfoDto
 ) {
 
-    public static OotdDetailDto from(Ootd ootd, User user, Perfume perfume, Boolean isLiked) {
-        return new OotdDetailDto(OotdInfoDto.from(ootd, isLiked), UserInfoDto.from(user), PerfumeInfoDto.from(perfume));
+    public static OotdDetailDto from(Ootd ootd, User user, List<Perfume> perfumes, Boolean isLiked) {
+        return new OotdDetailDto(OotdInfoDto.from(ootd, isLiked), UserInfoDto.from(user),
+                perfumes.stream().map(PerfumeInfoDto::from).toList());
     }
 }

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdLikeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdLikeDto.java
@@ -1,7 +1,0 @@
-package com.itsuda.perfume.dto.response.ootd;
-
-public record OotdLikeDto(
-        Long ootdId,
-        Boolean isLiked
-) {
-}

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdThumbnailDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/OotdThumbnailDto.java
@@ -2,6 +2,8 @@ package com.itsuda.perfume.dto.response.ootd;
 
 import com.itsuda.perfume.repository.OotdRepository.OotdThumbnailInfo;
 
+import java.util.Optional;
+
 public record OotdThumbnailDto(
         Long ootdId,
         String ootdImageUrl,
@@ -11,7 +13,7 @@ public record OotdThumbnailDto(
         return new OotdThumbnailDto(
                 ootdThumbnailInfo.getOotdId(),
                 ootdThumbnailInfo.getOotdImageUrl(),
-                ootdThumbnailInfo.getIsLiked() == 1
+                ootdThumbnailInfo.getIsLiked()
         );
     }
 }

--- a/src/main/java/com/itsuda/perfume/dto/response/perfume/OotdPerfumeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/perfume/OotdPerfumeDto.java
@@ -1,0 +1,9 @@
+package com.itsuda.perfume.dto.response.perfume;
+
+public record OotdPerfumeDto(
+        Long perfumeId,
+        String imageUri,
+        String brand,
+        String name
+) {
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/perfume/OotdPerfumesDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/perfume/OotdPerfumesDto.java
@@ -1,0 +1,8 @@
+package com.itsuda.perfume.dto.response.perfume;
+
+import java.util.List;
+
+public record OotdPerfumesDto(
+        List<OotdPerfumeDto> perfumes
+) {
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/post/PostCommentLikeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/post/PostCommentLikeDto.java
@@ -1,0 +1,7 @@
+package com.itsuda.perfume.dto.response.post;
+
+public record PostCommentLikeDto(
+        Boolean isLiked,
+        int likeCount
+) {
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/post/PostCommentLikeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/post/PostCommentLikeDto.java
@@ -1,7 +1,0 @@
-package com.itsuda.perfume.dto.response.post;
-
-public record PostCommentLikeDto(
-        Boolean isLiked,
-        int likeCount
-) {
-}

--- a/src/main/java/com/itsuda/perfume/dto/response/post/PostLikeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/post/PostLikeDto.java
@@ -1,7 +1,0 @@
-package com.itsuda.perfume.dto.response.post;
-
-public record PostLikeDto(
-        Long postId,
-        Boolean isLiked
-) {
-}

--- a/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
+++ b/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     INVALID_COMMENT_COMMENT("1400", HttpStatus.BAD_REQUEST, "댓글은 공백이 아닌 1자 이상이 포함되어야 합니다"),
     INVALID_TAG("1400", HttpStatus.BAD_REQUEST, "태그는 공백이 아닌 1~15자여야 하며 공백문자를 포함하면 안됩니다"),
     INVALID_IMAGE("1400", HttpStatus.BAD_REQUEST, "이미지는 jpg, jpeq, png만 지원하며 최소 1장에서 최대 5장까지 첨부해야 합니다."),
+    INVALID_PERFUME_LIST("1400", HttpStatus.BAD_REQUEST, "향수는 최소 1개에서 최대 3개까지 등록해야 합니다"),
     NICKNAME_ALREADY_EXISTS("1400", HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다"),
     NICKNAME_CONTAINS_FORBIDDEN("1400", HttpStatus.BAD_REQUEST, "사용할 수 없는 단어가 포함되어 있습니다"),
     INVALID_POTENTIAL_TYPE("1400", HttpStatus.BAD_REQUEST, "유효하지 않은 부향률 타입입니다"),

--- a/src/main/java/com/itsuda/perfume/intercepter/UserIdArgumentResolver.java
+++ b/src/main/java/com/itsuda/perfume/intercepter/UserIdArgumentResolver.java
@@ -12,6 +12,8 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.util.Optional;
+
 @Component
 @Slf4j
 public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
@@ -37,11 +39,11 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
         final Object userIdObj = webRequest.getAttribute("USER_ID", WebRequest.SCOPE_REQUEST);
 
         //없으면 예외처리
-        if (userIdObj == null) {
+        if (parameter.getParameterAnnotation(UserId.class).required() && userIdObj == null) {
             log.info("User_ID 없음");
             throw new RestApiException(ErrorCode.ACCESS_DENIED_ERROR);
         }
         //Long 타입으로 변환해 반환
-        return Long.valueOf(userIdObj.toString());
+        return Optional.ofNullable(userIdObj).map(userId -> Long.valueOf(userId.toString())).orElse(null);
     }
 }

--- a/src/main/java/com/itsuda/perfume/repository/OotdPerfumeRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/OotdPerfumeRepository.java
@@ -1,0 +1,12 @@
+package com.itsuda.perfume.repository;
+
+import com.itsuda.perfume.domain.Ootd;
+import com.itsuda.perfume.domain.OotdPerfume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OotdPerfumeRepository extends JpaRepository<OotdPerfume, Long> {
+
+    List<OotdPerfume> findByOotd(Ootd otd);
+}

--- a/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
@@ -16,15 +16,15 @@ public interface OotdRepository extends JpaRepository<Ootd, Long> {
     Optional<Ootd> findById(Long id);
 
     @Query(value = "SELECT o.id AS ootdId, oi.save_name AS ootdImageUrl, " +
-            "CASE WHEN ulo.id IS NULL THEN 0 ELSE 1 END AS isLiked FROM ootd o " +
+            "CASE WHEN ulo.id IS NULL THEN FALSE ELSE TRUE END AS isLiked FROM ootd o " +
             "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id " +
-            "LEFT JOIN user_like_ootd ulo ON ulo.user_id = :userId AND ulo.ootd_id = o.id ",
+            "LEFT JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id ",
             nativeQuery = true)
     Page<OotdThumbnailInfo> findAllIncludingUserLiked(Pageable pageable, Long userId);
 
     interface OotdThumbnailInfo {
         Long getOotdId();
         String getOotdImageUrl();
-        int getIsLiked();
+        boolean getIsLiked();
     }
 }

--- a/src/main/java/com/itsuda/perfume/repository/PerfumeRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/PerfumeRepository.java
@@ -39,4 +39,6 @@ public interface PerfumeRepository extends JpaRepository<Perfume, Long> {
         @Param("brands") List<BrandType> brands, 
         @Param("countries") List<CountryType> countries
     );
+
+    List<Perfume> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/itsuda/perfume/repository/UserLikeCommentRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/UserLikeCommentRepository.java
@@ -1,0 +1,15 @@
+package com.itsuda.perfume.repository;
+
+import com.itsuda.perfume.domain.Comment;
+import com.itsuda.perfume.domain.User;
+import com.itsuda.perfume.domain.UserLikeComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserLikeCommentRepository extends JpaRepository<UserLikeComment, Long> {
+
+    Optional<UserLikeComment> findByCommentAndUser(Comment comment, User user);
+
+    Boolean existsByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/com/itsuda/perfume/repository/WishPerfumeRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/WishPerfumeRepository.java
@@ -1,0 +1,13 @@
+package com.itsuda.perfume.repository;
+
+import com.itsuda.perfume.domain.Perfume;
+import com.itsuda.perfume.domain.User;
+import com.itsuda.perfume.domain.WishPerfume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WishPerfumeRepository extends JpaRepository<WishPerfume, Long> {
+
+    Optional<WishPerfume> findByPerfumeAndCustomer(Perfume perfume, User customer);
+}

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -18,9 +18,7 @@ import com.itsuda.perfume.dto.response.PageInfoDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
 import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
-import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
-import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.dto.response.ootd.OotdThumbnailDto;
 import com.itsuda.perfume.exception.RestApiException;
@@ -149,7 +147,7 @@ public class OotdService {
 
     // TODO - 추후 처리율 제한과 비동기 처리 예정
     @Transactional
-    public OotdLikeDto sendLikeToOotd(Long ootdId, Long userId) {
+    public void sendLikeToOotd(Long ootdId, Long userId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         Optional<UserFcmToken> userFcmToken = userFcmTokenRepository.findByUser(ootd.getUser());
@@ -158,7 +156,7 @@ public class OotdService {
         if (userLikeOotd.isPresent()) {
             userLikeOotdRepository.delete(userLikeOotd.get());
             ootd.decreaseLikeCount();
-            return new OotdLikeDto(ootd.getId(), false);
+            return;
         }
 
         userLikeOotdRepository.save(UserLikeOotd.builder().ootd(ootd).user(user).build());
@@ -175,7 +173,6 @@ public class OotdService {
                     fcmService.sendFCMMessage(notification.getTitle(), notification.getBodyMessage(), fcmToken.getFcmToken());
                 }
         );
-        return new OotdLikeDto(ootd.getId(), true);
     }
 
     @Transactional
@@ -210,17 +207,18 @@ public class OotdService {
     }
 
     @Transactional
-    public OotdCommentLikeDto sendLikeToOotdComment(Long userId, Long commentId) {
+    public void sendLikeToOotdComment(Long userId, Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
 
         Optional<UserLikeComment> userLikeComment = userLikeCommentRepository.findByCommentAndUser(comment, user);
         if (userLikeComment.isPresent()) {
             userLikeCommentRepository.delete(userLikeComment.get());
-            return new OotdCommentLikeDto(false, comment.decreaseLikeCount());
+            comment.decreaseLikeCount();
+            return;
         }
 
         userLikeCommentRepository.save(UserLikeComment.builder().comment(comment).user(user).build());
-        return new OotdCommentLikeDto(true, comment.increaseLikeCount());
+        comment.increaseLikeCount();
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -1,8 +1,8 @@
 package com.itsuda.perfume.service;
 
 import com.itsuda.perfume.domain.Comment;
-import com.itsuda.perfume.domain.OotdCommentNotification;
 import com.itsuda.perfume.domain.Ootd;
+import com.itsuda.perfume.domain.OotdCommentNotification;
 import com.itsuda.perfume.domain.OotdImage;
 import com.itsuda.perfume.domain.OotdLikeNotification;
 import com.itsuda.perfume.domain.OotdTag;
@@ -10,12 +10,14 @@ import com.itsuda.perfume.domain.Perfume;
 import com.itsuda.perfume.domain.Tag;
 import com.itsuda.perfume.domain.User;
 import com.itsuda.perfume.domain.UserFcmToken;
+import com.itsuda.perfume.domain.UserLikeComment;
 import com.itsuda.perfume.domain.UserLikeOotd;
 import com.itsuda.perfume.domain.type.OotdOrderType;
 import com.itsuda.perfume.dto.response.PageInfoDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
 import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
+import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
@@ -31,6 +33,7 @@ import com.itsuda.perfume.repository.OotdTagRepository;
 import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.TagRepository;
 import com.itsuda.perfume.repository.UserFcmTokenRepository;
+import com.itsuda.perfume.repository.UserLikeCommentRepository;
 import com.itsuda.perfume.repository.UserLikeOotdRepository;
 import com.itsuda.perfume.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +50,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_COMMENT;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_OOTD;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_PERFUME;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_USER;
@@ -68,6 +72,7 @@ public class OotdService {
     private final FcmService fcmService;
     private final UserFcmTokenRepository userFcmTokenRepository;
     private final OotdCommentNotificationRepository ootdCommentNotificationRepository;
+    private final UserLikeCommentRepository userLikeCommentRepository;
 
     // TODO - 추후 전략 패턴 도입
     public OotdMainDto getOotdThumbnailsByOrderType(int page, int size, OotdOrderType ootdOrderType, Long userId) {
@@ -195,5 +200,20 @@ public class OotdService {
                 }
         );
         return new OotdCommentDto(comment.getId());
+    }
+
+    @Transactional
+    public OotdCommentLikeDto sendLikeToOotdComment(Long userId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+
+        Optional<UserLikeComment> userLikeComment = userLikeCommentRepository.findByCommentAndUser(comment, user);
+        if (userLikeComment.isPresent()) {
+            userLikeCommentRepository.delete(userLikeComment.get());
+            return new OotdCommentLikeDto(false, comment.decreaseLikeCount());
+        }
+
+        userLikeCommentRepository.save(UserLikeComment.builder().comment(comment).user(user).build());
+        return new OotdCommentLikeDto(true, comment.increaseLikeCount());
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -5,6 +5,7 @@ import com.itsuda.perfume.domain.Ootd;
 import com.itsuda.perfume.domain.OotdCommentNotification;
 import com.itsuda.perfume.domain.OotdImage;
 import com.itsuda.perfume.domain.OotdLikeNotification;
+import com.itsuda.perfume.domain.OotdPerfume;
 import com.itsuda.perfume.domain.OotdTag;
 import com.itsuda.perfume.domain.Perfume;
 import com.itsuda.perfume.domain.Tag;
@@ -27,6 +28,7 @@ import com.itsuda.perfume.repository.CommentRepository;
 import com.itsuda.perfume.repository.OotdCommentNotificationRepository;
 import com.itsuda.perfume.repository.OotdImageRepository;
 import com.itsuda.perfume.repository.OotdLikeNotificationRepository;
+import com.itsuda.perfume.repository.OotdPerfumeRepository;
 import com.itsuda.perfume.repository.OotdRepository;
 import com.itsuda.perfume.repository.OotdRepository.OotdThumbnailInfo;
 import com.itsuda.perfume.repository.OotdTagRepository;
@@ -52,7 +54,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_COMMENT;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_OOTD;
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_PERFUME;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_USER;
 
 @Service
@@ -67,6 +68,7 @@ public class OotdService {
     private final UserLikeCommentRepository userLikeCommentRepository;
     private final UserLikeOotdRepository userLikeOotdRepository;
     private final UserFcmTokenRepository userFcmTokenRepository;
+    private final OotdPerfumeRepository ootdPerfumeRepository;
     private final OotdImageRepository ootdImageRepository;
     private final CommentRepository commentRepository;
     private final PerfumeRepository perfumeRepository;
@@ -102,16 +104,15 @@ public class OotdService {
     }
 
     @Transactional
-    public CreatedOotdDto createOotd(Long userId, String content, List<String> tagNames, int volume, Long perfumeId,
+    public CreatedOotdDto createOotd(Long userId, String content, List<String> tagNames, int volume, List<Long> perfumeId,
                                      List<MultipartFile> images) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
-        Perfume perfume = perfumeRepository.findById(perfumeId).orElseThrow(() -> new RestApiException(NOT_FOUND_PERFUME));
+        List<Perfume> perfumes = perfumeRepository.findByIdIn(perfumeId);
 
         AtomicInteger atomicInt = new AtomicInteger(0);
         Ootd ootd = ootdRepository.save(Ootd.builder()
                 .likeCount(0)
                 .volume(volume)
-                .perfume(perfume)
                 .user(user)
                 .content(content).build());
         ootdImageRepository.saveAll(images.stream().map(image -> OotdImage.builder()
@@ -119,8 +120,10 @@ public class OotdService {
                 .originName(image.getOriginalFilename())
                 .saveName(UUID.randomUUID().toString())
                 .sequence(atomicInt.getAndIncrement()).build()).toList());
-        List<Tag> savedTags = tagRepository.saveAll(tagNames.stream()
-                .map(tag -> Tag.builder().name(tag).build()).toList());
+        ootdPerfumeRepository.saveAll(perfumes.stream().map(perfume -> OotdPerfume.builder().ootd(ootd)
+                .perfume(perfume).build()).toList());
+        List<Tag> savedTags = tagRepository.saveAll(tagNames.stream().map(tag -> Tag.builder().name(tag).build()).toList());
+
         ootdTagRepository.saveAll(savedTags.stream().map(tag -> OotdTag.builder().ootd(ootd).tag(tag).build()).toList());
 
         return new CreatedOotdDto(ootd.getId());
@@ -129,9 +132,10 @@ public class OotdService {
     public OotdDetailDto getOotdDetailByOotdId(Long ootdId, Long userId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+        List<OotdPerfume> ootdPerfumes = ootdPerfumeRepository.findByOotd(ootd);
         Boolean isLiked = userLikeOotdRepository.existsByUserAndOotd(user, ootd);
 
-        return OotdDetailDto.from(ootd, ootd.getUser(), ootd.getPerfume(), isLiked);
+        return OotdDetailDto.from(ootd, ootd.getUser(), ootdPerfumes.stream().map(OotdPerfume::getPerfume).toList(), isLiked);
     }
 
     public CommentsDto getCommentsByOotdId(Long ootdId) {

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -60,19 +60,20 @@ import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_USER;
 @Transactional(readOnly = true)
 public class OotdService {
 
-    private final OotdRepository ootdRepository;
-    private final OotdImageRepository ootdImageRepository;
-    private final UserRepository userRepository;
+    private final FcmService fcmService;
+
+    private final OotdCommentNotificationRepository ootdCommentNotificationRepository;
+    private final OotdLikeNotificationRepository ootdLikeNotificationRepository;
+    private final UserLikeCommentRepository userLikeCommentRepository;
     private final UserLikeOotdRepository userLikeOotdRepository;
+    private final UserFcmTokenRepository userFcmTokenRepository;
+    private final OotdImageRepository ootdImageRepository;
     private final CommentRepository commentRepository;
-    private final TagRepository tagRepository;
     private final PerfumeRepository perfumeRepository;
     private final OotdTagRepository ootdTagRepository;
-    private final OotdLikeNotificationRepository ootdLikeNotificationRepository;
-    private final FcmService fcmService;
-    private final UserFcmTokenRepository userFcmTokenRepository;
-    private final OotdCommentNotificationRepository ootdCommentNotificationRepository;
-    private final UserLikeCommentRepository userLikeCommentRepository;
+    private final OotdRepository ootdRepository;
+    private final UserRepository userRepository;
+    private final TagRepository tagRepository;
 
     // TODO - 추후 전략 패턴 도입
     public OotdMainDto getOotdThumbnailsByOrderType(int page, int size, OotdOrderType ootdOrderType, Long userId) {

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -131,9 +131,11 @@ public class OotdService {
 
     public OotdDetailDto getOotdDetailByOotdId(Long ootdId, Long userId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
-        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         List<OotdPerfume> ootdPerfumes = ootdPerfumeRepository.findByOotd(ootd);
-        Boolean isLiked = userLikeOotdRepository.existsByUserAndOotd(user, ootd);
+        boolean isLiked = Optional.ofNullable(userId).map(usId -> {
+            User user = userRepository.findById(usId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+            return userLikeOotdRepository.existsByUserAndOotd(user, ootd);
+        }).orElse(false);
 
         return OotdDetailDto.from(ootd, ootd.getUser(), ootdPerfumes.stream().map(OotdPerfume::getPerfume).toList(), isLiked);
     }

--- a/src/main/java/com/itsuda/perfume/service/PerfumeService.java
+++ b/src/main/java/com/itsuda/perfume/service/PerfumeService.java
@@ -4,6 +4,8 @@ import com.itsuda.perfume.domain.Perfume;
 import com.itsuda.perfume.domain.PerfumeAccord;
 import com.itsuda.perfume.domain.PerfumeDetail;
 import com.itsuda.perfume.domain.PerfumeVolume;
+import com.itsuda.perfume.domain.User;
+import com.itsuda.perfume.domain.WishPerfume;
 import com.itsuda.perfume.dto.request.PerfumeRequestDto;
 import com.itsuda.perfume.dto.response.PerfumeAccordDto;
 import com.itsuda.perfume.dto.response.PerfumeDetailDto;
@@ -17,12 +19,15 @@ import com.itsuda.perfume.repository.PerfumeAccordRepository;
 import com.itsuda.perfume.repository.PerfumeDetailRepository;
 import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.PerfumeVolumeRepository;
+import com.itsuda.perfume.repository.UserRepository;
+import com.itsuda.perfume.repository.WishPerfumeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,6 +39,8 @@ public class PerfumeService {
     private final PerfumeVolumeRepository perfumeVolumeRepository;
     private final PerfumeDetailRepository perfumeDetailRepository;
     private final PerfumeAccordRepository perfumeAccordRepository;
+    private final UserRepository userRepository;
+    private final WishPerfumeRepository wishPerfumeRepository;
 
     // 향수 목록 조회
     public List<PerfumeListDto> getPerfumes(PerfumeRequestDto perfumeRequestDto) {
@@ -81,5 +88,25 @@ public class PerfumeService {
                         perfume.getBrand().getDescription(), perfume.getName())).toList();
 
         return new OotdPerfumesDto(ootdPerfumes);
+    }
+
+    public void sendWishToPerfume(Long perfumeId, Long userId) {
+        Perfume perfume = perfumeRepository.findById(perfumeId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_PERFUME));
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_USER));
+        Optional<WishPerfume> wishPerfume = wishPerfumeRepository.findByPerfumeAndCustomer(perfume, user);
+
+        wishPerfume.ifPresentOrElse(
+                wish -> {
+                    if (wish.changeWishStatus()) {
+                        perfume.increaseLikeCount();
+                    } else {
+                        perfume.decreaseLikeCount();
+                    }
+                },
+                () -> {
+                    wishPerfumeRepository.save(WishPerfume.builder().perfume(perfume).customer(user).build());
+                    perfume.increaseLikeCount();
+                }
+        );
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/PerfumeService.java
+++ b/src/main/java/com/itsuda/perfume/service/PerfumeService.java
@@ -1,28 +1,28 @@
 package com.itsuda.perfume.service;
 
 import com.itsuda.perfume.domain.Perfume;
+import com.itsuda.perfume.domain.PerfumeAccord;
 import com.itsuda.perfume.domain.PerfumeDetail;
 import com.itsuda.perfume.domain.PerfumeVolume;
+import com.itsuda.perfume.dto.request.PerfumeRequestDto;
 import com.itsuda.perfume.dto.response.PerfumeAccordDto;
 import com.itsuda.perfume.dto.response.PerfumeDetailDto;
+import com.itsuda.perfume.dto.response.PerfumeListDto;
+import com.itsuda.perfume.dto.response.perfume.OotdPerfumeDto;
+import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.exception.ErrorCode;
 import com.itsuda.perfume.exception.RestApiException;
 import com.itsuda.perfume.repository.AccordRepository;
+import com.itsuda.perfume.repository.PerfumeAccordRepository;
 import com.itsuda.perfume.repository.PerfumeDetailRepository;
+import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.PerfumeVolumeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
-import com.itsuda.perfume.dto.request.PerfumeRequestDto;
-import com.itsuda.perfume.dto.response.PerfumeListDto;
-import com.itsuda.perfume.repository.PerfumeRepository;
-import com.itsuda.perfume.domain.PerfumeAccord;
-import com.itsuda.perfume.repository.PerfumeAccordRepository;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,13 +38,13 @@ public class PerfumeService {
     // 향수 목록 조회
     public List<PerfumeListDto> getPerfumes(PerfumeRequestDto perfumeRequestDto) {
         return perfumeRepository.findBySearchOptions(
-            perfumeRequestDto.getMinPrice(),
-            perfumeRequestDto.getMaxPrice(),
-            perfumeRequestDto.getGenders(),
-            perfumeRequestDto.getAccords(),
-            perfumeRequestDto.getPotentials(),
-            perfumeRequestDto.getBrands(),
-            perfumeRequestDto.getCountries()
+                perfumeRequestDto.getMinPrice(),
+                perfumeRequestDto.getMaxPrice(),
+                perfumeRequestDto.getGenders(),
+                perfumeRequestDto.getAccords(),
+                perfumeRequestDto.getPotentials(),
+                perfumeRequestDto.getBrands(),
+                perfumeRequestDto.getCountries()
         ).stream().map(PerfumeListDto::from).toList();
     }
 
@@ -56,8 +56,8 @@ public class PerfumeService {
     // 향수 상세 조회
     public PerfumeDetailDto getPerfumeDetail(Long perfumeId) {
         Perfume perfume = perfumeRepository.findById(perfumeId)
-            .orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_PERFUME));
-        
+                .orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_PERFUME));
+
         List<PerfumeVolume> perfumeVolume = perfumeVolumeRepository.findByPerfume(perfume);
         if (perfumeVolume.isEmpty()) {
             throw new RestApiException(ErrorCode.NOT_FOUND_PERFUME_VOLUME);
@@ -68,10 +68,18 @@ public class PerfumeService {
         if (perfumeAccords.isEmpty()) {
             throw new RestApiException(ErrorCode.NOT_FOUND_ACCORD);
         }
-        
+
         PerfumeDetail perfumeDetail = perfumeDetailRepository.findByPerfume(perfume)
-            .orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_PERFUME_DETAIL));
+                .orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_PERFUME_DETAIL));
 
         return PerfumeDetailDto.from(perfume, perfumeVolume, perfumeAccords, perfumeDetail);
+    }
+
+    public OotdPerfumesDto getAllPerfumes() {
+        List<OotdPerfumeDto> ootdPerfumes = perfumeRepository.findAll().stream()
+                .map(perfume -> new OotdPerfumeDto(perfume.getId(), perfume.getImageUri(),
+                        perfume.getBrand().getDescription(), perfume.getName())).toList();
+
+        return new OotdPerfumesDto(ootdPerfumes);
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/PostService.java
+++ b/src/main/java/com/itsuda/perfume/service/PostService.java
@@ -15,11 +15,9 @@ import com.itsuda.perfume.dto.response.PageInfoDto;
 import com.itsuda.perfume.dto.response.post.CommentsDto;
 import com.itsuda.perfume.dto.response.post.CreatedPostDto;
 import com.itsuda.perfume.dto.response.post.PostCommentDto;
-import com.itsuda.perfume.dto.response.post.PostCommentLikeDto;
 import com.itsuda.perfume.dto.response.post.PostDetailDto;
 import com.itsuda.perfume.dto.response.post.PostDto;
 import com.itsuda.perfume.dto.response.post.PostInfoDto;
-import com.itsuda.perfume.dto.response.post.PostLikeDto;
 import com.itsuda.perfume.dto.response.post.PostMainDto;
 import com.itsuda.perfume.dto.response.post.UserInfoDto;
 import com.itsuda.perfume.exception.ErrorCode;
@@ -120,7 +118,7 @@ public class PostService {
 
     // TODO - 추후 처리율 제한과 비동기 처리 예정
     @Transactional
-    public PostLikeDto sendLikeToPost(Long postId, Long userId) {
+    public void sendLikeToPost(Long postId, Long userId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUNT_POST));
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         Optional<UserFcmToken> userFcmToken = userFcmTokenRepository.findByUser(post.getUser());
@@ -129,7 +127,7 @@ public class PostService {
         if (userLikePost.isPresent()) {
             userLikePostRepository.delete(userLikePost.get());
             post.decreaseLikeCount();
-            return new PostLikeDto(post.getId(), false);
+            return;
         }
 
         userLikePostRepository.save(UserLikePost.builder().post(post).user(user).build());
@@ -146,7 +144,6 @@ public class PostService {
                     fcmService.sendFCMMessage(notification.getTitle(), notification.getBodyMessage(), fcmToken.getFcmToken());
                 }
         );
-        return new PostLikeDto(post.getId(), true);
     }
 
     @Transactional
@@ -181,17 +178,18 @@ public class PostService {
     }
 
     @Transactional
-    public PostCommentLikeDto sendLikeToPostComment(Long userId, Long commentId) {
+    public void sendLikeToPostComment(Long userId, Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
 
         Optional<UserLikeComment> userLikeComment = userLikeCommentRepository.findByCommentAndUser(comment, user);
         if (userLikeComment.isPresent()) {
             userLikeCommentRepository.delete(userLikeComment.get());
-            return new PostCommentLikeDto(false, comment.decreaseLikeCount());
+            comment.decreaseLikeCount();
+            return;
         }
 
         userLikeCommentRepository.save(UserLikeComment.builder().comment(comment).user(user).build());
-        return new PostCommentLikeDto(true, comment.increaseLikeCount());
+        comment.increaseLikeCount();
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/PostService.java
+++ b/src/main/java/com/itsuda/perfume/service/PostService.java
@@ -8,12 +8,14 @@ import com.itsuda.perfume.domain.PostTag;
 import com.itsuda.perfume.domain.Tag;
 import com.itsuda.perfume.domain.User;
 import com.itsuda.perfume.domain.UserFcmToken;
+import com.itsuda.perfume.domain.UserLikeComment;
 import com.itsuda.perfume.domain.UserLikePost;
 import com.itsuda.perfume.domain.type.PostOrderType;
 import com.itsuda.perfume.dto.response.PageInfoDto;
 import com.itsuda.perfume.dto.response.post.CommentsDto;
 import com.itsuda.perfume.dto.response.post.CreatedPostDto;
 import com.itsuda.perfume.dto.response.post.PostCommentDto;
+import com.itsuda.perfume.dto.response.post.PostCommentLikeDto;
 import com.itsuda.perfume.dto.response.post.PostDetailDto;
 import com.itsuda.perfume.dto.response.post.PostDto;
 import com.itsuda.perfume.dto.response.post.PostInfoDto;
@@ -29,6 +31,7 @@ import com.itsuda.perfume.repository.PostRepository;
 import com.itsuda.perfume.repository.PostTagRepository;
 import com.itsuda.perfume.repository.TagRepository;
 import com.itsuda.perfume.repository.UserFcmTokenRepository;
+import com.itsuda.perfume.repository.UserLikeCommentRepository;
 import com.itsuda.perfume.repository.UserLikePostRepository;
 import com.itsuda.perfume.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_COMMENT;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_USER;
 import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUNT_POST;
 
@@ -60,6 +64,7 @@ public class PostService {
     private final UserFcmTokenRepository userFcmTokenRepository;
     private final PostLikeNotificationRepository postLikeNotificationRepository;
     private final PostCommentNotificationRepository postCommentNotificationRepository;
+    private final UserLikeCommentRepository userLikeCommentRepository;
 
     // TODO - 추후 전략 패턴 도입
     public PostMainDto getPostsByOrderType(int page, int size, PostOrderType postOrderType) {
@@ -175,4 +180,18 @@ public class PostService {
         return new PostCommentDto(comment.getId());
     }
 
+    @Transactional
+    public PostCommentLikeDto sendLikeToPostComment(Long userId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+
+        Optional<UserLikeComment> userLikeComment = userLikeCommentRepository.findByCommentAndUser(comment, user);
+        if (userLikeComment.isPresent()) {
+            userLikeCommentRepository.delete(userLikeComment.get());
+            return new PostCommentLikeDto(false, comment.decreaseLikeCount());
+        }
+
+        userLikeCommentRepository.save(UserLikeComment.builder().comment(comment).user(user).build());
+        return new PostCommentLikeDto(true, comment.increaseLikeCount());
+    }
 }

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -92,7 +92,7 @@ class OotdControllerTest {
     @Test
     void ootdMustHaveContent() throws Exception {
         // given
-        CreateOotdDto request = new CreateOotdDto("", 10, 10L, List.of("태그1", "태그2"));
+        CreateOotdDto request = new CreateOotdDto("", 10, List.of(10L), List.of("태그1", "태그2"));
         MockMultipartFile image1 = new MockMultipartFile("images", "1.png",
                 MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
         MockMultipartFile image2 = new MockMultipartFile("images", "2.png",
@@ -118,7 +118,7 @@ class OotdControllerTest {
     @Test
     void tagSizeIsSmallerOrEqualThan10() throws Exception {
         // given
-        CreateOotdDto request = new CreateOotdDto("test content", 10, 10L,
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(10L),
                 List.of("태그1", "태그2", "태그3", "태그4", "태그5", "태그6", "태그7", "태그8", "태그9", "태그10", "태그11"));
         MockMultipartFile image1 = new MockMultipartFile("images", "1.png",
                 MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
@@ -146,7 +146,7 @@ class OotdControllerTest {
     @ParameterizedTest
     void tagIsNotBlankAndSmallerOrEqualThan15AndNotContainSpace(String tag) throws Exception {
         // given
-        CreateOotdDto request = new CreateOotdDto("test content", 10, 10L, List.of(tag));
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(10L), List.of(tag));
         MockMultipartFile image1 = new MockMultipartFile("images", "1.png",
                 MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
         MockMultipartFile image2 = new MockMultipartFile("images", "2.png",
@@ -169,11 +169,63 @@ class OotdControllerTest {
                         .value("태그는 공백이 아닌 1~15자여야 하며 공백문자를 포함하면 안됩니다"));
     }
 
+    @DisplayName("OOTD 게시글을 작성할 때 향수를 반드시 등록해야 한다.")
+    @Test
+    void ootdMustHavePerfume() throws Exception {
+        // given
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(), List.of("태그1", "태그2"));
+        MockMultipartFile image1 = new MockMultipartFile("images", "1.png",
+                MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
+        MockMultipartFile image2 = new MockMultipartFile("images", "2.png",
+                MediaType.IMAGE_JPEG_VALUE, "2".getBytes());
+        MockMultipartFile image3 = new MockMultipartFile("images", "3.png",
+                MediaType.IMAGE_JPEG_VALUE, "3".getBytes());
+        MockMultipartFile json = new MockMultipartFile("createOotdDto", "createOotdDto.json",
+                MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
+
+        // when  // then
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/api/v1/ootds")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .file(json)
+                        .with(csrf()))
+                .andExpect(jsonPath("$.result").value("1400"))
+                .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.toString()))
+                .andExpect(jsonPath("$.message").value("향수는 최소 1개에서 최대 3개까지 등록해야 합니다"));
+    }
+
+    @DisplayName("OOTD 게시글을 작성할 때 향수는 최대 3개까지 등록할 수 있다.")
+    @Test
+    void ootdPerfumeIsGreaterTahn1SmallerOrEqualThan3() throws Exception {
+        // given
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(10L, 20L, 30L, 40L), List.of("태그1", "태그2"));
+        MockMultipartFile image1 = new MockMultipartFile("images", "1.png",
+                MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
+        MockMultipartFile image2 = new MockMultipartFile("images", "2.png",
+                MediaType.IMAGE_JPEG_VALUE, "2".getBytes());
+        MockMultipartFile image3 = new MockMultipartFile("images", "3.png",
+                MediaType.IMAGE_JPEG_VALUE, "3".getBytes());
+        MockMultipartFile json = new MockMultipartFile("createOotdDto", "createOotdDto.json",
+                MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
+
+        // when  // then
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/api/v1/ootds")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .file(json)
+                        .with(csrf()))
+                .andExpect(jsonPath("$.result").value("1400"))
+                .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.toString()))
+                .andExpect(jsonPath("$.message").value("향수는 최소 1개에서 최대 3개까지 등록해야 합니다"));
+    }
+
     @DisplayName("OOTD 게시글을 작성할 때 이미지를 반드시 첨부해야 한다.")
     @Test
     void ootdMustHaveImage() throws Exception {
         // given
-        CreateOotdDto request = new CreateOotdDto("test content", 10, 10L, List.of("태그1", "태그2"));
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(10L), List.of("태그1", "태그2"));
         MockMultipartFile json = new MockMultipartFile("createOotdDto", "createOotdDto.json",
                 MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
 
@@ -191,7 +243,7 @@ class OotdControllerTest {
     @Test
     void ootdImageIsSmallerOrEqualThan5() throws Exception {
         // given
-        CreateOotdDto request = new CreateOotdDto("test content", 10, 10L, List.of("태그1", "태그2"));
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(10L), List.of("태그1", "태그2"));
         MockMultipartFile image1 = new MockMultipartFile("images", "1.png",
                 MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
         MockMultipartFile image2 = new MockMultipartFile("images", "2.png",
@@ -228,7 +280,7 @@ class OotdControllerTest {
     @Test
     void ootdImageExtensionIsPngOrJpgOrJpeg() throws Exception {
         // given
-        CreateOotdDto request = new CreateOotdDto("test content", 10, 10L, List.of("태그1", "태그2"));
+        CreateOotdDto request = new CreateOotdDto("test content", 10, List.of(10L), List.of("태그1", "태그2"));
         MockMultipartFile image1 = new MockMultipartFile("images", "1.gif",
                 MediaType.IMAGE_JPEG_VALUE, "1".getBytes());
         MockMultipartFile image2 = new MockMultipartFile("images", "2.jpg",

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -30,7 +30,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -5,9 +5,7 @@ import com.itsuda.perfume.domain.type.OotdOrderType;
 import com.itsuda.perfume.dto.request.ootd.CreateOotdDto;
 import com.itsuda.perfume.dto.request.ootd.OotdCommentRequestDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
-import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
-import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.service.OotdService;
@@ -340,9 +338,7 @@ class OotdControllerTest {
     @Test
     void sendLikeToOotd() throws Exception {
         // given
-        OotdLikeDto result = new OotdLikeDto(null, null);
-
-        Mockito.when(ootdService.sendLikeToOotd(anyLong(), anyLong())).thenReturn(result);
+        Mockito.doNothing().when(ootdService).sendLikeToOotd(anyLong(), anyLong());
 
         // when // then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/ootds/1/like").with(csrf()))
@@ -369,9 +365,7 @@ class OotdControllerTest {
     @Test
     void sendLikeToOotdComment() throws Exception {
         // given
-        OotdCommentLikeDto result = new OotdCommentLikeDto(null, 1);
-
-        Mockito.when(ootdService.sendLikeToOotdComment(anyLong(), anyLong())).thenReturn(result);
+        Mockito.doNothing().when(ootdService).sendLikeToOotdComment(anyLong(), anyLong());
 
         // when // then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/ootds/1/comments/0/like").with(csrf()))

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -5,6 +5,7 @@ import com.itsuda.perfume.domain.type.OotdOrderType;
 import com.itsuda.perfume.dto.request.ootd.CreateOotdDto;
 import com.itsuda.perfume.dto.request.ootd.OotdCommentRequestDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
+import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
@@ -292,5 +293,19 @@ class OotdControllerTest {
                 .andExpect(jsonPath("$.result").value("1400"))
                 .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.toString()))
                 .andExpect(jsonPath("$.message").value("댓글은 공백이 아닌 1자 이상이 포함되어야 합니다"));
+    }
+
+    @DisplayName("OOTD 게시글의 댓글에 좋아요를 눌러서 좋아요를 요청한다.")
+    @Test
+    void sendLikeToOotdComment() throws Exception {
+        // given
+        OotdCommentLikeDto result = new OotdCommentLikeDto(null, 1);
+
+        Mockito.when(ootdService.sendLikeToOotdComment(anyLong(), anyLong())).thenReturn(result);
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/ootds/1/comments/0/like").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
     }
 }

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -9,7 +9,9 @@ import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
+import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.service.OotdService;
+import com.itsuda.perfume.service.PerfumeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +30,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,6 +48,9 @@ class OotdControllerTest {
 
     @MockBean
     private OotdService ootdService;
+
+    @MockBean
+    private PerfumeService perfumeService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -65,6 +71,19 @@ class OotdControllerTest {
                                 .queryParam("page", "0")
                                 .queryParam("size", "3")
                 )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+    }
+
+    @DisplayName("OOTD 게시글 작성 중, 향수의 목록을 조회한다.")
+    @Test
+    void getOotdPerfumes() throws Exception {
+        // given
+        OotdPerfumesDto result = new OotdPerfumesDto(null);
+        Mockito.when(perfumeService.getAllPerfumes()).thenReturn(result);
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/ootds/perfumes"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result").value("1200"));
     }

--- a/src/test/java/com/itsuda/perfume/controller/PerfumeControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/PerfumeControllerTest.java
@@ -1,0 +1,41 @@
+package com.itsuda.perfume.controller;
+
+import com.itsuda.perfume.service.PerfumeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PerfumeController.class)
+@WithMockUser
+@ActiveProfiles("test")
+class PerfumeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PerfumeService perfumeService;
+
+    @DisplayName("특정 향수를 위시에 담는다.")
+    @Test
+    void sendWishToPerfume() throws Exception {
+        // given
+        Mockito.doNothing().when(perfumeService).sendWishToPerfume(anyLong(), anyLong());
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/perfumes/1/like"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+    }
+}

--- a/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
@@ -5,9 +5,7 @@ import com.itsuda.perfume.domain.type.PostOrderType;
 import com.itsuda.perfume.dto.request.post.CreatePostDto;
 import com.itsuda.perfume.dto.request.post.PostCommentRequestDto;
 import com.itsuda.perfume.dto.response.post.CommentsDto;
-import com.itsuda.perfume.dto.response.post.PostCommentLikeDto;
 import com.itsuda.perfume.dto.response.post.PostDetailDto;
-import com.itsuda.perfume.dto.response.post.PostLikeDto;
 import com.itsuda.perfume.dto.response.post.PostMainDto;
 import com.itsuda.perfume.service.PostService;
 import org.junit.jupiter.api.DisplayName;
@@ -158,9 +156,7 @@ class PostControllerTest {
     @Test
     void likePost() throws Exception {
         // given
-        PostLikeDto result = new PostLikeDto(null, null);
-
-        Mockito.when(postService.sendLikeToPost(anyLong(), anyLong())).thenReturn(result);
+        Mockito.doNothing().when(postService).sendLikeToPost(anyLong(), anyLong());
 
         // when // then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts/1/like").with(csrf()))
@@ -187,9 +183,7 @@ class PostControllerTest {
     @Test
     void sendLikeToPostComment() throws Exception {
         // given
-        PostCommentLikeDto result = new PostCommentLikeDto(null, 1);
-
-        Mockito.when(postService.sendLikeToPostComment(anyLong(), anyLong())).thenReturn(result);
+        Mockito.doNothing().when(postService).sendLikeToPostComment(anyLong(), anyLong());
 
         // when // then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts/1/comments/0/like").with(csrf()))

--- a/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
@@ -5,6 +5,7 @@ import com.itsuda.perfume.domain.type.PostOrderType;
 import com.itsuda.perfume.dto.request.post.CreatePostDto;
 import com.itsuda.perfume.dto.request.post.PostCommentRequestDto;
 import com.itsuda.perfume.dto.response.post.CommentsDto;
+import com.itsuda.perfume.dto.response.post.PostCommentLikeDto;
 import com.itsuda.perfume.dto.response.post.PostDetailDto;
 import com.itsuda.perfume.dto.response.post.PostLikeDto;
 import com.itsuda.perfume.dto.response.post.PostMainDto;
@@ -182,4 +183,17 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.message").value("댓글은 공백이 아닌 1자 이상이 포함되어야 합니다"));
     }
 
+    @DisplayName("자유게시글의 댓글에 좋아요를 눌러서 좋아요를 요청한다.")
+    @Test
+    void sendLikeToPostComment() throws Exception {
+        // given
+        PostCommentLikeDto result = new PostCommentLikeDto(null, 1);
+
+        Mockito.when(postService.sendLikeToPostComment(anyLong(), anyLong())).thenReturn(result);
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts/1/comments/0/like").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+    }
 }

--- a/src/test/java/com/itsuda/perfume/repository/OotdImageRepositoryTest.java
+++ b/src/test/java/com/itsuda/perfume/repository/OotdImageRepositoryTest.java
@@ -121,7 +121,6 @@ class OotdImageRepositoryTest {
                 .likeCount(number)
                 .volume(10 * number)
                 .content("test" + number)
-                .perfume(perfume)
                 .user(user)
                 .build();
     }

--- a/src/test/java/com/itsuda/perfume/repository/OotdRepositoryTest.java
+++ b/src/test/java/com/itsuda/perfume/repository/OotdRepositoryTest.java
@@ -138,7 +138,7 @@ class OotdRepositoryTest {
         // then
         assertThat(ootdThumbnailInfos.getContent()).hasSize(3)
                 .extracting(OotdThumbnailInfo::getIsLiked)
-                .containsExactly(1, 0, 1);
+                .containsExactly(true, false, true);
     }
 
     @DisplayName("OOTD 게시글 특정 번호에 해당하는 하나의 게시글과 사진들의 정보를 가져온다.")

--- a/src/test/java/com/itsuda/perfume/repository/OotdRepositoryTest.java
+++ b/src/test/java/com/itsuda/perfume/repository/OotdRepositoryTest.java
@@ -183,7 +183,6 @@ class OotdRepositoryTest {
                 .likeCount(number)
                 .volume(10 * number)
                 .content("test" + number)
-                .perfume(perfume)
                 .user(user)
                 .build();
     }

--- a/src/test/java/com/itsuda/perfume/repository/UserLikeOotdRepositoryTest.java
+++ b/src/test/java/com/itsuda/perfume/repository/UserLikeOotdRepositoryTest.java
@@ -98,7 +98,6 @@ class UserLikeOotdRepositoryTest {
                 .likeCount(number)
                 .volume(10 * number)
                 .content("test" + number)
-                .perfume(perfume)
                 .user(user)
                 .build();
     }

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -18,6 +18,7 @@ import com.itsuda.perfume.dto.response.ootd.CommentInfoDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
 import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
+import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.repository.CommentRepository;
@@ -27,6 +28,7 @@ import com.itsuda.perfume.repository.OotdLikeNotificationRepository;
 import com.itsuda.perfume.repository.OotdRepository;
 import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.UserFcmTokenRepository;
+import com.itsuda.perfume.repository.UserLikeCommentRepository;
 import com.itsuda.perfume.repository.UserLikeOotdRepository;
 import com.itsuda.perfume.repository.UserRepository;
 import jakarta.persistence.EntityManager;
@@ -100,6 +102,9 @@ class OotdServiceTest {
 
     @Autowired
     private OotdCommentNotificationRepository ootdCommentNotificationRepository;
+
+    @Autowired
+    private UserLikeCommentRepository userLikeCommentRepository;
 
     @Autowired
     private EntityManager em;
@@ -419,6 +424,39 @@ class OotdServiceTest {
         // then
         assertThat(notifications).hasSize(1);
         assertThat(notifications).extracting("commentWriter").containsExactly(user);
+    }
+
+    @DisplayName("댓글에 좋아요를 요청하면 좋아요가 1만큼 오르고 사용자는 댓글에 좋아요를 누른 것을 확인할 수 있다.")
+    @Test
+    void increaseOotdCommentLikesAndCheckLike() {
+        // given
+        Ootd ootd = ootdRepository.save(createOotd(0));
+        Comment comment = commentRepository.save(createComment(0, null, ootd, user));
+        int originLikeCount = comment.getLikeCount();
+
+        // when
+        ootdService.sendLikeToOotdComment(user.getId(), comment.getId());
+
+        // then
+        assertThat(comment.getLikeCount()).isEqualTo(originLikeCount + 1);
+        assertThat(userLikeCommentRepository.existsByUserAndComment(user, comment)).isTrue();
+    }
+
+    @DisplayName("사용자가 좋아요를 누른 댓글에 좋아요를 한번 더 누르면 좋아요가 취소된다.")
+    @Test
+    void cancelLikeToLikedOotdComment() {
+        // given
+        Ootd ootd = ootdRepository.save(createOotd(0));
+        Comment comment = commentRepository.save(createComment(0, null, ootd, user));
+        ootdService.sendLikeToOotdComment(user.getId(), comment.getId());
+        int originLikeCount = comment.getLikeCount();
+
+        // when
+        ootdService.sendLikeToOotdComment(user.getId(), comment.getId());
+
+        // then
+        assertThat(comment.getLikeCount()).isEqualTo(originLikeCount - 1);
+        assertThat(userLikeCommentRepository.existsByUserAndComment(user, comment)).isFalse();
     }
 
     private void setMockingTime(int minute) {

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -18,13 +18,13 @@ import com.itsuda.perfume.dto.response.ootd.CommentInfoDto;
 import com.itsuda.perfume.dto.response.ootd.CommentsDto;
 import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
-import com.itsuda.perfume.dto.response.ootd.OotdCommentLikeDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.repository.CommentRepository;
 import com.itsuda.perfume.repository.OotdCommentNotificationRepository;
 import com.itsuda.perfume.repository.OotdImageRepository;
 import com.itsuda.perfume.repository.OotdLikeNotificationRepository;
+import com.itsuda.perfume.repository.OotdPerfumeRepository;
 import com.itsuda.perfume.repository.OotdRepository;
 import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.UserFcmTokenRepository;
@@ -105,6 +105,9 @@ class OotdServiceTest {
 
     @Autowired
     private UserLikeCommentRepository userLikeCommentRepository;
+
+    @Autowired
+    private OotdPerfumeRepository ootdPerfumeRepository;
 
     @Autowired
     private EntityManager em;
@@ -219,7 +222,7 @@ class OotdServiceTest {
 
     @DisplayName("OOTD에 이미지와 태그, 내용, 향수 정보를 가지는 게시글을 생성한다.")
     @Test
-    void createPost() {
+    void createOotd() {
         // given
         String content = "test content";
         List<String> tags = List.of();
@@ -228,18 +231,17 @@ class OotdServiceTest {
                 new MockMultipartFile("test file3", "test3.png", MediaType.IMAGE_JPEG_VALUE, "test3".getBytes()));
 
         // when
-        CreatedOotdDto result = ootdService.createOotd(user.getId(), content, tags, 10, perfume.getId(), mockMultipartFiles);
+        CreatedOotdDto result = ootdService.createOotd(user.getId(), content, tags, 10, List.of(perfume.getId()), mockMultipartFiles);
 
         // then
         Optional<Ootd> ootd = ootdRepository.findById(result.ootdId());
         assertThat(ootd).isPresent();
-        assertThat(ootd.get()).extracting("content", "perfume")
-                .contains(content, perfume);
+        assertThat(ootd.get()).extracting("content", "user").contains(content, user);
     }
 
     @DisplayName("OOTD에 특정 태그를 가지는 게시글을 생성한다.")
     @Test
-    void createPostTags() {
+    void createOotdTags() {
         // given
         String content = "test content";
         List<String> tags = List.of("2025", "향수", "느좋");
@@ -248,7 +250,7 @@ class OotdServiceTest {
                 new MockMultipartFile("test file3", "test3.png", MediaType.IMAGE_JPEG_VALUE, "test3".getBytes()));
 
         // when
-        CreatedOotdDto result = ootdService.createOotd(user.getId(), content, tags, 10, perfume.getId(), mockMultipartFiles);
+        CreatedOotdDto result = ootdService.createOotd(user.getId(), content, tags, 10, List.of(perfume.getId()), mockMultipartFiles);
         em.flush();
         em.clear();
 
@@ -256,6 +258,29 @@ class OotdServiceTest {
         Ootd ootd = ootdRepository.findById(result.ootdId()).get();
         assertThat(ootd.getOotdTags()).extracting(ootdTag -> ootdTag.getTag().getName())
                 .contains("2025", "향수", "느좋");
+    }
+
+    @DisplayName("OOTD에는 여러 개의 향수를 첨부할 수 있다.")
+    @Test
+    void createOotdWithMultiplePerfumes() {
+        // given
+        String content = "test content";
+        List<String> tags = List.of("2025", "향수", "느좋");
+        List<MultipartFile> mockMultipartFiles = List.of(
+                new MockMultipartFile("test1", "test1.png", MediaType.IMAGE_JPEG_VALUE, "test1".getBytes()));
+        List<Perfume> perfumes = perfumeRepository.saveAll(List.of(
+                createPerfume("test1"),
+                createPerfume("test2"),
+                createPerfume("test3")));
+
+        // when
+        CreatedOotdDto result = ootdService.createOotd(user.getId(), content, tags, 10,
+                perfumes.stream().map(Perfume::getId).toList(), mockMultipartFiles);
+
+        // then
+        Ootd ootd = ootdRepository.findById(result.ootdId()).get();
+        assertThat(ootdPerfumeRepository.findByOotd(ootd)).extracting("perfume")
+                .containsAll(perfumes);
     }
 
     @DisplayName("OOTD 게시글 아이디에 해당하는 OOTD 게시글의 정보와 이미지들을 조회한다.")
@@ -471,7 +496,6 @@ class OotdServiceTest {
                 .likeCount(number)
                 .volume(10 * number)
                 .content("test" + number)
-                .perfume(perfume)
                 .user(user)
                 .build();
     }
@@ -499,6 +523,19 @@ class OotdServiceTest {
                 .build();
         user.updateBirthDate("2000-05-02");
         return user;
+    }
+
+    private static Perfume createPerfume(String name) {
+        return Perfume.builder()
+                .name(name + " perfume")
+                .imageUri(name + " url")
+                .gender(GenderType.MALE)
+                .brand(BrandType.CHANEL)
+                .country(CountryType.FRANCE)
+                .potential(PotentialType.EDT)
+                .description(name + " desc")
+                .registeredAt(LocalDate.of(2025, 2, 1))
+                .build();
     }
 
     private static Perfume createTestPerfume() {

--- a/src/test/java/com/itsuda/perfume/service/PerfumeServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PerfumeServiceTest.java
@@ -1,0 +1,68 @@
+package com.itsuda.perfume.service;
+
+import com.itsuda.perfume.domain.Perfume;
+import com.itsuda.perfume.domain.type.BrandType;
+import com.itsuda.perfume.domain.type.CountryType;
+import com.itsuda.perfume.domain.type.GenderType;
+import com.itsuda.perfume.domain.type.PotentialType;
+import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
+import com.itsuda.perfume.repository.PerfumeRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class PerfumeServiceTest {
+
+    @Autowired
+    private PerfumeService perfumeService;
+
+    @Autowired
+    private PerfumeRepository perfumeRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @DisplayName("모든 향수들의 목록을 조회할 수 있다.")
+    @Test
+    void getAllPerfumes() {
+        // given
+        List<Perfume> perfumes = perfumeRepository.saveAll(List.of(createPerfume("test1"),
+                createPerfume("test2"),
+                createPerfume("test3")));
+        em.flush();
+        em.clear();
+
+        // when
+        OotdPerfumesDto result = perfumeService.getAllPerfumes();
+
+        // then
+        assertThat(result.perfumes())
+                .extracting("perfumeId")
+                .containsSequence(perfumes.stream().map(Perfume::getId).toList());
+    }
+
+    private static Perfume createPerfume(String name) {
+        return Perfume.builder()
+                .name(name + " perfume")
+                .imageUri(name + " url")
+                .gender(GenderType.MALE)
+                .brand(BrandType.CHANEL)
+                .country(CountryType.FRANCE)
+                .potential(PotentialType.EDT)
+                .description(name + " desc")
+                .registeredAt(LocalDate.of(2025, 2, 1))
+                .build();
+    }
+}

--- a/src/test/java/com/itsuda/perfume/service/PerfumeServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PerfumeServiceTest.java
@@ -1,12 +1,18 @@
 package com.itsuda.perfume.service;
 
 import com.itsuda.perfume.domain.Perfume;
+import com.itsuda.perfume.domain.User;
+import com.itsuda.perfume.domain.WishPerfume;
 import com.itsuda.perfume.domain.type.BrandType;
 import com.itsuda.perfume.domain.type.CountryType;
+import com.itsuda.perfume.domain.type.EProvider;
+import com.itsuda.perfume.domain.type.ERole;
 import com.itsuda.perfume.domain.type.GenderType;
 import com.itsuda.perfume.domain.type.PotentialType;
 import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.repository.PerfumeRepository;
+import com.itsuda.perfume.repository.UserRepository;
+import com.itsuda.perfume.repository.WishPerfumeRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +37,12 @@ class PerfumeServiceTest {
 
     @Autowired
     private PerfumeRepository perfumeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private WishPerfumeRepository wishPerfumeRepository;
 
     @Autowired
     EntityManager em;
@@ -53,6 +66,61 @@ class PerfumeServiceTest {
                 .containsSequence(perfumes.stream().map(Perfume::getId).toList());
     }
 
+    @DisplayName("사용자는 향수를 위시에 담고, 본인이 담은 위시 항목에서 해당 향수를 볼 수 있다.")
+    @Test
+    void userCanSendWishToPerfume() {
+        // given
+        Perfume perfume = perfumeRepository.save(createPerfume("test"));
+        User user = userRepository.save(createTestUser());
+        em.flush();
+        em.clear();
+
+        // when
+        perfumeService.sendWishToPerfume(perfume.getId(), user.getId());
+
+        // then
+        assertThat(wishPerfumeRepository.findByPerfumeAndCustomer(perfume, user)).isPresent();
+    }
+
+    @DisplayName("향수에 위시를 요청하면 향수의 위시 수가 1만큼 오르고 사용자는 향수에 위시를 누른 것을 확인할 수 있다.")
+    @Test
+    void increaseOotdCommentLikesAndCheckLike() {
+        // given
+        Perfume perfume = perfumeRepository.save(createPerfume("test"));
+        User user = userRepository.save(createTestUser());
+        int originWishCount = perfume.getWishCount();
+        em.flush();
+        em.clear();
+
+        // when
+        perfumeService.sendWishToPerfume(perfume.getId(), user.getId());
+        Optional<WishPerfume> wishPerfume = wishPerfumeRepository.findByPerfumeAndCustomer(perfume, user);
+
+        // then
+        assertThat(wishPerfume).isPresent();
+        assertThat(wishPerfume.get().getPerfume().getWishCount()).isEqualTo(originWishCount + 1);
+    }
+
+    @DisplayName("사용자가 위시를 누른 향수에 위시를 한번 더 누르면 위시가 취소된다.")
+    @Test
+    void cancelLikeToLikedOotdComment() {
+        // given
+        Perfume perfume = perfumeRepository.save(createPerfume("test"));
+        User user = userRepository.save(createTestUser());
+        perfumeService.sendWishToPerfume(perfume.getId(), user.getId());
+        int originWishCount = perfume.getWishCount();
+        em.flush();
+        em.clear();
+
+        // when
+        perfumeService.sendWishToPerfume(perfume.getId(), user.getId());
+        Optional<WishPerfume> wishPerfume = wishPerfumeRepository.findByPerfumeAndCustomer(perfume, user);
+
+        // then
+        assertThat(wishPerfume).isPresent();
+        assertThat(wishPerfume.get().getPerfume().getWishCount()).isEqualTo(originWishCount - 1);
+    }
+
     private static Perfume createPerfume(String name) {
         return Perfume.builder()
                 .name(name + " perfume")
@@ -64,5 +132,21 @@ class PerfumeServiceTest {
                 .description(name + " desc")
                 .registeredAt(LocalDate.of(2025, 2, 1))
                 .build();
+    }
+
+    private static User createTestUser() {
+        User user = User.builder()
+                .email("test@test.com")
+                .gender(GenderType.MALE)
+                .imageUrl("test url")
+                .nickname("test nickname")
+                .presentation("test")
+                .provider(EProvider.GOOGLE)
+                .role(ERole.USER)
+                .serialId("123")
+                .username("test")
+                .build();
+        user.updateBirthDate("2000-05-02");
+        return user;
     }
 }

--- a/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
@@ -1,7 +1,6 @@
 package com.itsuda.perfume.service;
 
 import com.itsuda.perfume.domain.Comment;
-import com.itsuda.perfume.domain.Ootd;
 import com.itsuda.perfume.domain.Post;
 import com.itsuda.perfume.domain.PostCommentNotification;
 import com.itsuda.perfume.domain.User;
@@ -23,6 +22,7 @@ import com.itsuda.perfume.repository.PostCommentNotificationRepository;
 import com.itsuda.perfume.repository.PostLikeNotificationRepository;
 import com.itsuda.perfume.repository.PostRepository;
 import com.itsuda.perfume.repository.UserFcmTokenRepository;
+import com.itsuda.perfume.repository.UserLikeCommentRepository;
 import com.itsuda.perfume.repository.UserLikePostRepository;
 import com.itsuda.perfume.repository.UserRepository;
 import jakarta.persistence.EntityManager;
@@ -79,11 +79,6 @@ class PostServiceTest {
     private UserFcmTokenRepository userFcmTokenRepository;
 
     @Autowired
-    private EntityManager em;
-
-    private User user;
-
-    @Autowired
     private UserLikePostRepository userLikePostRepository;
 
     @Autowired
@@ -91,6 +86,14 @@ class PostServiceTest {
 
     @Autowired
     private PostCommentNotificationRepository postCommentNotificationRepository;
+
+    @Autowired
+    private UserLikeCommentRepository userLikeCommentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User user;
 
     @BeforeEach
     void setUp() {
@@ -414,6 +417,39 @@ class PostServiceTest {
         // then
         assertThat(notifications).hasSize(1);
         assertThat(notifications).extracting("commentWriter").containsExactly(user);
+    }
+
+    @DisplayName("댓글에 좋아요를 요청하면 좋아요가 1만큼 오르고 사용자는 댓글에 좋아요를 누른 것을 확인할 수 있다.")
+    @Test
+    void increasePostCommentLikesAndCheckLike() {
+        // given
+        Post post = postRepository.save(createPost(0, user));
+        Comment comment = commentRepository.save(createComment(0, null, post, user));
+        int originLikeCount = comment.getLikeCount();
+
+        // when
+        postService.sendLikeToPostComment(user.getId(), comment.getId());
+
+        // then
+        assertThat(comment.getLikeCount()).isEqualTo(originLikeCount + 1);
+        assertThat(userLikeCommentRepository.existsByUserAndComment(user, comment)).isTrue();
+    }
+
+    @DisplayName("사용자가 좋아요를 누른 댓글에 좋아요를 한번 더 누르면 좋아요가 취소된다.")
+    @Test
+    void cancelLikeToLikedOotdComment() {
+        // given
+        Post post = postRepository.save(createPost(0, user));
+        Comment comment = commentRepository.save(createComment(0, null, post, user));
+        postService.sendLikeToPostComment(user.getId(), comment.getId());
+        int originLikeCount = comment.getLikeCount();
+
+        // when
+        postService.sendLikeToPostComment(user.getId(), comment.getId());
+
+        // then
+        assertThat(comment.getLikeCount()).isEqualTo(originLikeCount - 1);
+        assertThat(userLikeCommentRepository.existsByUserAndComment(user, comment)).isFalse();
     }
 
     private void setMockingTime(int minute) {


### PR DESCRIPTION
## ✨ Description
- 댓글 좋아요 기능, 향수 불러오기 기능, 향수 좋아요 기능을 추가했습니다. 또한 기존 사용자 정보 불러오기 어노테이션인 UserId에 required 속성을 추가하여 social에서 사용자 기능을 불러올때 발생하는 오류를 제어하도록 했습니다.
- 향수 등록에서 다중 등록이 가능하게 수정했고, 배포 시 테스트 성공 여부에 상관없이 배포하도록 커맨드를 수정했습니다.
- 모든 좋아요 기능들의 응답을 무응답으로 수정했습니다.

---

## 🔗 Related Issue
- Closes #48 
