### PR TITLE
Feat: 좋아요 모아보기 및 소셜 삭제 기능 구현

### DIFF
--- a/src/main/java/com/itsuda/perfume/controller/LikeController.java
+++ b/src/main/java/com/itsuda/perfume/controller/LikeController.java
@@ -2,13 +2,18 @@ package com.itsuda.perfume.controller;
 
 import com.itsuda.perfume.annotation.UserId;
 import com.itsuda.perfume.domain.type.OotdOrderType;
+import com.itsuda.perfume.domain.type.PerfumeOrderType;
+import com.itsuda.perfume.dto.request.like.WishPerfumeRequestDto;
+import com.itsuda.perfume.dto.response.like.WishPerfumesDto;
 import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
 import com.itsuda.perfume.exception.ResponseDto;
 import com.itsuda.perfume.service.OotdService;
+import com.itsuda.perfume.service.PerfumeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LikeController {
 
     private final OotdService ootdService;
+    private final PerfumeService perfumeService;
 
     @Operation(summary = "OOTD 좋아요 모아보기", description = "좋아요를 누른 OOTD들을 순서에 맞게 조회합니다.")
     @GetMapping("/ootds")
@@ -28,5 +34,16 @@ public class LikeController {
             @RequestParam(required = false, defaultValue = "NEWEST_DESCENDING") OotdOrderType order,
             @RequestParam int page, @RequestParam int size) {
         return new ResponseDto<>(ootdService.getAllUserLikeOotdsByOrderType(page, size, order, 0L));
+    }
+
+    @Operation(summary = "향수 위시 모아보기", description = "위시리스트에 담은 향수들을 조회합니다.")
+    @GetMapping("/perfumes")
+    public ResponseDto<WishPerfumesDto> getWishPerfumes(
+            @UserId Long userId,
+            @ModelAttribute WishPerfumeRequestDto wishPerfumeRequestDto,
+            @RequestParam(required = false, defaultValue = "REGISTERED_AT_DESCENDING") PerfumeOrderType order,
+            @RequestParam int page, @RequestParam int size
+    ) {
+        return new ResponseDto<>(perfumeService.getAllWishPerfumes(wishPerfumeRequestDto, page, size, order, userId));
     }
 }

--- a/src/main/java/com/itsuda/perfume/controller/LikeController.java
+++ b/src/main/java/com/itsuda/perfume/controller/LikeController.java
@@ -1,0 +1,32 @@
+package com.itsuda.perfume.controller;
+
+import com.itsuda.perfume.annotation.UserId;
+import com.itsuda.perfume.domain.type.OotdOrderType;
+import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
+import com.itsuda.perfume.exception.ResponseDto;
+import com.itsuda.perfume.service.OotdService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/likes")
+@Tag(name = "Like", description = "좋아요 모아보기 관련 API")
+public class LikeController {
+
+    private final OotdService ootdService;
+
+    @Operation(summary = "OOTD 좋아요 모아보기", description = "좋아요를 누른 OOTD들을 순서에 맞게 조회합니다.")
+    @GetMapping("/ootds")
+    public ResponseDto<UserLikeOotdsDto> getUserLikeOotds(
+            @UserId Long userId,
+            @RequestParam(required = false, defaultValue = "NEWEST_DESCENDING") OotdOrderType order,
+            @RequestParam int page, @RequestParam int size) {
+        return new ResponseDto<>(ootdService.getAllUserLikeOotdsByOrderType(page, size, order, 0L));
+    }
+}

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -99,6 +99,13 @@ public class OotdController {
                 postComment.commentId(), postComment.comment()));
     }
 
+    @Operation(summary = "OOTD 댓글 삭제", description = "OOTD 댓글을 삭제합니다.")
+    @DeleteMapping("/{ootdId}/comments/{commentId}")
+    public ResponseDto<Void> deleteOotdCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
+        ootdService.deleteOotdComment(userId, commentId);
+        return new ResponseDto<>(null);
+    }
+
     @Operation(summary = "OOTD 댓글 좋아요", description = "OOTD 게시글의 댓글에 좋아요를 요청합니다.")
     @PostMapping("/{ootdId}/comments/{commentId}/like")
     public ResponseDto<Void> likeOotdCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,6 +68,13 @@ public class OotdController {
     public ResponseDto<OotdDetailDto> getOotdDetailByOotdID(@UserId(required = false) Long userId,
                                                             @PathVariable Long ootdId) {
         return new ResponseDto<>(ootdService.getOotdDetailByOotdId(ootdId, userId));
+    }
+
+    @Operation(summary = "OOTD 삭제", description = "OOTD ID에 맞는 게시글을 삭제합니다.")
+    @DeleteMapping("/{ootdId}")
+    public ResponseDto<Void> deleteOotdByOotdId(@UserId Long userId, @PathVariable Long ootdId) {
+        ootdService.deleteOotdByOotdId(ootdId, userId);
+        return new ResponseDto<>(null);
     }
 
     @Operation(summary = "OOTD 좋아요", description = "OOTD 게시글에 좋아요를 요청합니다.")

--- a/src/main/java/com/itsuda/perfume/controller/PostController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PostController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,6 +55,13 @@ public class PostController {
         return new ResponseDto<>(postService.getPostDetailByPostId(postId));
     }
 
+    @Operation(summary = "자유게시글 삭제", description = "자유게시판에서 게시글 ID에 맞는 게시글을 삭제합니다.")
+    @DeleteMapping("/{postId}")
+    public ResponseDto<Void> deletePostByPostId(@UserId Long userId, @PathVariable Long postId) {
+        postService.deletePostByPostId(postId, userId);
+        return new ResponseDto<>(null);
+    }
+
     @Operation(summary = "자유게시글 좋아요", description = "자유게시판 게시글에 좋아요를 요청합니다.")
     @PostMapping("/{postId}/like")
     public ResponseDto<Void> likePostByPostId(@UserId Long userId, @PathVariable Long postId) {
@@ -73,6 +81,13 @@ public class PostController {
             @UserId Long userId, @PathVariable Long postId, @Valid @RequestBody PostCommentRequestDto postComment) {
         return new ResponseDto<>(postService.writeCommentToPost(postId, userId,
                 postComment.commentId(), postComment.comment()));
+    }
+
+    @Operation(summary = "자유게시글 댓글 삭제", description = "자유게시글의 댓글 ID에 맞는 댓글을 삭제합니다.")
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseDto<Void> deletePostCommentByCommentId(@UserId Long userId, @PathVariable Long commentId) {
+        postService.deletePostComment(commentId, userId);
+        return new ResponseDto<>(null);
     }
 
     @Operation(summary = "자유게시글 댓글 좋아요", description = "자유게시글의 댓글에 좋아요를 요청합니다.")

--- a/src/main/java/com/itsuda/perfume/domain/Comment.java
+++ b/src/main/java/com/itsuda/perfume/domain/Comment.java
@@ -13,11 +13,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import java.util.List;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE comment SET deleted_at = NOW(), content = '삭제된 댓글입니다', like_count = 0 WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends ModifiableBaseEntity {
 

--- a/src/main/java/com/itsuda/perfume/domain/Ootd.java
+++ b/src/main/java/com/itsuda/perfume/domain/Ootd.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE ootd SET deleted_at = NOW() WHERE id = ?")
 public class Ootd extends ModifiableBaseEntity {
 
     @Id

--- a/src/main/java/com/itsuda/perfume/domain/Post.java
+++ b/src/main/java/com/itsuda/perfume/domain/Post.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id = ?")
 public class Post extends ModifiableBaseEntity {
 
     @Id

--- a/src/main/java/com/itsuda/perfume/domain/type/PerfumeOrderType.java
+++ b/src/main/java/com/itsuda/perfume/domain/type/PerfumeOrderType.java
@@ -1,0 +1,17 @@
+package com.itsuda.perfume.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum PerfumeOrderType {
+    REGISTERED_AT_DESCENDING("등록순"),
+    REGISTERED_AT_ASCENDING("역등록순"),
+    POPULAR_DESCENDING("인기순"),
+    POPULAR_ASCENDING("역인기순");
+
+    private final String description;
+
+    PerfumeOrderType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/itsuda/perfume/dto/request/like/WishPerfumeRequestDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/request/like/WishPerfumeRequestDto.java
@@ -1,0 +1,43 @@
+package com.itsuda.perfume.dto.request.like;
+
+import com.itsuda.perfume.domain.type.BrandType;
+import com.itsuda.perfume.domain.type.CountryType;
+import com.itsuda.perfume.domain.type.GenderType;
+import com.itsuda.perfume.domain.type.PotentialType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springdoc.core.annotations.ParameterObject;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "향수 검색 조건")
+@ParameterObject
+public class WishPerfumeRequestDto {
+    @Schema(description = "최소 가격", example = "100000", minimum = "0")
+    private Integer minPrice;
+
+    @Schema(description = "최대 가격", example = "500000", minimum = "0")
+    private Integer maxPrice;
+
+    @Schema(description = "성별", example = "FEMALE,UNISEX", examples = {"FEMALE", "UNISEX", "MALE", "UNKNOWN"})
+    private List<GenderType> genders;
+
+    @Schema(description = "향 계열", example = "만다린,바닐라", examples = {"만다린", "바닐라", "바이올렛", "베르가못", "..."})
+    private List<String> accords;
+
+    @Schema(description = "향의 강도", example = "EDP,EDT", examples = {"EDP", "EDT", "EDC", "PERFUME"})
+    private List<PotentialType> potentials;
+
+    @Schema(description = "브랜드", example = "DIOR,CHANEL", examples = {"CHANEL", "DIOR", "GUCCI", "JO MALONE", "CREED", "BYREDO", "..."})
+    private List<BrandType> brands;
+
+    @Schema(description = "원산지", example = "FRANCE,ITALY", examples = {"FRANCE", "ITALY", "USA", "..."})
+    private List<CountryType> countries;
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/like/WishPerfumeDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/like/WishPerfumeDto.java
@@ -1,0 +1,16 @@
+package com.itsuda.perfume.dto.response.like;
+
+import com.itsuda.perfume.domain.Perfume;
+
+public record WishPerfumeDto(
+        Long perfumeId,
+        String imageUri,
+        String brand,
+        String name
+) {
+
+    public static WishPerfumeDto from(Perfume perfume) {
+        return new WishPerfumeDto(perfume.getId(), perfume.getImageUri(), perfume.getBrand().getDescription(),
+                perfume.getName());
+    }
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/like/WishPerfumesDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/like/WishPerfumesDto.java
@@ -1,0 +1,15 @@
+package com.itsuda.perfume.dto.response.like;
+
+import com.itsuda.perfume.domain.Perfume;
+import com.itsuda.perfume.dto.response.PageInfoDto;
+
+import java.util.List;
+
+public record WishPerfumesDto(
+        List<WishPerfumeDto> dataList,
+        PageInfoDto pageInfo
+) {
+    public static WishPerfumesDto from(List<Perfume> perfumes, PageInfoDto pageInfoDto) {
+        return new WishPerfumesDto(perfumes.stream().map(WishPerfumeDto::from).toList(), pageInfoDto);
+    }
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/UserLikeOotdDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/UserLikeOotdDto.java
@@ -1,0 +1,12 @@
+package com.itsuda.perfume.dto.response.ootd;
+
+import com.itsuda.perfume.repository.OotdRepository.UserLikeOotdInfo;
+
+public record UserLikeOotdDto(
+        Long ootdId,
+        String ootdImageUrl
+) {
+    public static UserLikeOotdDto from(UserLikeOotdInfo userLikeOotdInfo) {
+        return new UserLikeOotdDto(userLikeOotdInfo.getOotdId(), userLikeOotdInfo.getOotdImageUrl());
+    }
+}

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/UserLikeOotdsDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/UserLikeOotdsDto.java
@@ -1,0 +1,16 @@
+package com.itsuda.perfume.dto.response.ootd;
+
+import com.itsuda.perfume.dto.response.PageInfoDto;
+import com.itsuda.perfume.repository.OotdRepository.UserLikeOotdInfo;
+
+import java.util.List;
+
+public record UserLikeOotdsDto(
+        List<UserLikeOotdDto> dataList,
+        PageInfoDto pageInfo
+) {
+
+    public static UserLikeOotdsDto from(List<UserLikeOotdInfo> userLikeOotds, PageInfoDto pageInfo) {
+        return new UserLikeOotdsDto(userLikeOotds.stream().map(UserLikeOotdDto::from).toList(), pageInfo);
+    }
+}

--- a/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
+++ b/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     NOT_FOUND_COMMENT("1404", HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다"),
     NOT_FOUND_OOTD("1404", HttpStatus.NOT_FOUND, "존재하지 않는 OOTD 게시글입니다"),
     NOT_FOUNT_POST("1404", HttpStatus.NOT_FOUND, "존재하는 자유게시글입니다"),
+    DELETED_OOTD("1404", HttpStatus.NOT_FOUND, "이미 삭제된 OOTD 게시글입니다"),
 
     // Bad Request Error
     NOT_END_POINT("1400", HttpStatus.BAD_REQUEST, "존재하지 않는 엔드포인트입니다"),
@@ -39,6 +40,8 @@ public enum ErrorCode {
     EMPTY_POST_TITLE("1400", HttpStatus.BAD_REQUEST, "자유게시글의 제목은 공백이 아닌 글자가 있어야합니다"),
     EMPTY_POST_CONTENT("1400", HttpStatus.BAD_REQUEST, "자유게시글의 내용은 공백이 아닌 글자가 있어야합니다"),
     EMPTY_OOTD_CONTENT("1400", HttpStatus.BAD_REQUEST, "OOTD의 내용은 공백이 아닌 글자가 있어야합니다"),
+    ONLY_OOTD_OWNER_DELETE("1400", HttpStatus.BAD_REQUEST, "OOTD 작성자만 OOTD 게시글을 삭제할 수 있습니다."),
+    ONLY_POST_OWNER_DELETE("1400", HttpStatus.BAD_REQUEST, "자유게시글 작성자만 자유게시글을 삭제할 수 있습니다."),
     FCM_TOKEN_INVALID_ERROR("1400", HttpStatus.BAD_REQUEST, "FCM 토큰 형식이 올바르지 않습니다"),
 
     // Server, File Up/DownLoad Error

--- a/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
+++ b/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     NOT_FOUND_OOTD("1404", HttpStatus.NOT_FOUND, "존재하지 않는 OOTD 게시글입니다"),
     NOT_FOUNT_POST("1404", HttpStatus.NOT_FOUND, "존재하는 자유게시글입니다"),
     DELETED_OOTD("1404", HttpStatus.NOT_FOUND, "이미 삭제된 OOTD 게시글입니다"),
+    DELETED_POST("1404", HttpStatus.NOT_FOUND, "이미 삭제된 자유게시글입니다"),
+    DELETED_COMMENT("1404", HttpStatus.NOT_FOUND, "이미 삭제된 댓글입니다"),
 
     // Bad Request Error
     NOT_END_POINT("1400", HttpStatus.BAD_REQUEST, "존재하지 않는 엔드포인트입니다"),
@@ -42,6 +44,7 @@ public enum ErrorCode {
     EMPTY_OOTD_CONTENT("1400", HttpStatus.BAD_REQUEST, "OOTD의 내용은 공백이 아닌 글자가 있어야합니다"),
     ONLY_OOTD_OWNER_DELETE("1400", HttpStatus.BAD_REQUEST, "OOTD 작성자만 OOTD 게시글을 삭제할 수 있습니다."),
     ONLY_POST_OWNER_DELETE("1400", HttpStatus.BAD_REQUEST, "자유게시글 작성자만 자유게시글을 삭제할 수 있습니다."),
+    ONLY_COMMENT_OWNER_DELETE("1400", HttpStatus.BAD_REQUEST, "댓글 작성자만 댓글을 삭제할 수 있습니다."),
     FCM_TOKEN_INVALID_ERROR("1400", HttpStatus.BAD_REQUEST, "FCM 토큰 형식이 올바르지 않습니다"),
 
     // Server, File Up/DownLoad Error

--- a/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
+++ b/src/main/java/com/itsuda/perfume/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
     NOT_FOUND_ACCORD("1404", HttpStatus.NOT_FOUND, "존재하지 않는 향입니다"),
     NOT_FOUND_COMMENT("1404", HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다"),
     NOT_FOUND_OOTD("1404", HttpStatus.NOT_FOUND, "존재하지 않는 OOTD 게시글입니다"),
-    NOT_FOUNT_POST("1404", HttpStatus.NOT_FOUND, "존재하는 자유게시글입니다"),
+    NOT_FOUND_POST("1404", HttpStatus.NOT_FOUND, "존재하는 자유게시글입니다"),
     DELETED_OOTD("1404", HttpStatus.NOT_FOUND, "이미 삭제된 OOTD 게시글입니다"),
     DELETED_POST("1404", HttpStatus.NOT_FOUND, "이미 삭제된 자유게시글입니다"),
     DELETED_COMMENT("1404", HttpStatus.NOT_FOUND, "이미 삭제된 댓글입니다"),

--- a/src/main/java/com/itsuda/perfume/repository/CommentRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/CommentRepository.java
@@ -7,12 +7,17 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @EntityGraph(attributePaths = "childComments")
+    @EntityGraph(attributePaths = {"childComments", "user"})
+    @Override
+    Optional<Comment> findById(Long commentId);
+
+    @EntityGraph(attributePaths = {"childComments", "user"})
     List<Comment> findAllByPostAndParentCommentIsNull(Post post);
 
-    @EntityGraph(attributePaths = "childComments")
+    @EntityGraph(attributePaths = {"childComments", "user"})
     List<Comment> findAllByOotdAndParentCommentIsNull(Ootd ootd);
 }

--- a/src/main/java/com/itsuda/perfume/repository/CommentRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/CommentRepository.java
@@ -19,5 +19,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByPostAndParentCommentIsNull(Post post);
 
     @EntityGraph(attributePaths = {"childComments", "user"})
-    List<Comment> findAllByOotdAndParentCommentIsNull(Ootd ootd);
+    List<Comment> findAllByOotdAndParentCommentIsNullAndDeletedAtIsNull(Ootd ootd);
 }

--- a/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
@@ -1,7 +1,6 @@
 package com.itsuda.perfume.repository;
 
 import com.itsuda.perfume.domain.Ootd;
-import com.itsuda.perfume.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -19,13 +18,15 @@ public interface OotdRepository extends JpaRepository<Ootd, Long> {
     @Query(value = "SELECT o.id AS ootdId, oi.save_name AS ootdImageUrl, " +
             "CASE WHEN ulo.id IS NULL THEN FALSE ELSE TRUE END AS isLiked FROM ootd o " +
             "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id " +
-            "LEFT JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id ",
+            "LEFT JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id " +
+            "WHERE o.deleted_at IS NULL",
             nativeQuery = true)
     Page<OotdThumbnailInfo> findAllIncludingUserLiked(Pageable pageable, Long userId);
 
     @Query(value = "SELECT o.id AS ootdId, oi.save_name AS ootdImageUrl FROM ootd o " +
             "INNER JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id " +
-            "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id ",
+            "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id " +
+            "WHERE o.deleted_at IS NULL",
             nativeQuery = true)
     Page<UserLikeOotdInfo> findAllUserLikeByUser(Pageable pageable, Long userId);
 

--- a/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
@@ -1,6 +1,7 @@
 package com.itsuda.perfume.repository;
 
 import com.itsuda.perfume.domain.Ootd;
+import com.itsuda.perfume.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -22,9 +23,23 @@ public interface OotdRepository extends JpaRepository<Ootd, Long> {
             nativeQuery = true)
     Page<OotdThumbnailInfo> findAllIncludingUserLiked(Pageable pageable, Long userId);
 
+    @Query(value = "SELECT o.id AS ootdId, oi.save_name AS ootdImageUrl FROM ootd o " +
+            "INNER JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id " +
+            "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id ",
+            nativeQuery = true)
+    Page<UserLikeOotdInfo> findAllUserLikeByUser(Pageable pageable, Long userId);
+
     interface OotdThumbnailInfo {
         Long getOotdId();
+
         String getOotdImageUrl();
+
         boolean getIsLiked();
+    }
+
+    interface UserLikeOotdInfo {
+        Long getOotdId();
+
+        String getOotdImageUrl();
     }
 }

--- a/src/main/java/com/itsuda/perfume/repository/PerfumeRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/PerfumeRepository.java
@@ -1,6 +1,7 @@
 package com.itsuda.perfume.repository;
 
 import com.itsuda.perfume.domain.Perfume;
+import com.itsuda.perfume.domain.User;
 import com.itsuda.perfume.domain.type.BrandType;
 import com.itsuda.perfume.domain.type.CountryType;
 import com.itsuda.perfume.domain.type.GenderType;
@@ -8,6 +9,8 @@ import com.itsuda.perfume.domain.type.PotentialType;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,26 +22,50 @@ public interface PerfumeRepository extends JpaRepository<Perfume, Long> {
     // 향수 목록 조회
     // 프로젝트가 확장되거나 검색 옵션이 바뀌는 경우 QueryDSL로 전환하는게 좋을 듯?
     @Query("SELECT DISTINCT p FROM Perfume p " +
-           "INNER JOIN p.perfumeVolumes pv " +
-           "LEFT JOIN p.perfumeAccords pa " +
-           "LEFT JOIN pa.accord a " +
-           "WHERE " +
-           "(:minPrice IS NULL OR pv.price >= :minPrice) AND " +
-           "(:maxPrice IS NULL OR pv.price <= :maxPrice) AND " +
-           "(:genders IS NULL OR p.gender IN :genders) AND " +
-           "(:accords IS NULL OR a.name IN :accords) AND " +
-           "(:potencies IS NULL OR p.potential IN :potencies) AND " +
-           "(:brands IS NULL OR p.brand IN :brands) AND " +
-           "(:countries IS NULL OR p.country IN :countries)")
+            "INNER JOIN p.perfumeVolumes pv " +
+            "LEFT JOIN p.perfumeAccords pa " +
+            "LEFT JOIN pa.accord a " +
+            "WHERE " +
+            "(:minPrice IS NULL OR pv.price >= :minPrice) AND " +
+            "(:maxPrice IS NULL OR pv.price <= :maxPrice) AND " +
+            "(:genders IS NULL OR p.gender IN :genders) AND " +
+            "(:accords IS NULL OR a.name IN :accords) AND " +
+            "(:potencies IS NULL OR p.potential IN :potencies) AND " +
+            "(:brands IS NULL OR p.brand IN :brands) AND " +
+            "(:countries IS NULL OR p.country IN :countries)")
     List<Perfume> findBySearchOptions(
-        @Param("minPrice") Integer minPrice, 
-        @Param("maxPrice") Integer maxPrice, 
-        @Param("genders") List<GenderType> genders, 
-        @Param("accords") List<String> accords, 
-        @Param("potencies") List<PotentialType> potencies, 
-        @Param("brands") List<BrandType> brands, 
-        @Param("countries") List<CountryType> countries
+            @Param("minPrice") Integer minPrice,
+            @Param("maxPrice") Integer maxPrice,
+            @Param("genders") List<GenderType> genders,
+            @Param("accords") List<String> accords,
+            @Param("potencies") List<PotentialType> potencies,
+            @Param("brands") List<BrandType> brands,
+            @Param("countries") List<CountryType> countries
     );
 
     List<Perfume> findByIdIn(List<Long> ids);
+
+    @Query(value = "SELECT DISTINCT p FROM Perfume p " +
+            "INNER JOIN WishPerfume wp ON p = wp.perfume AND wp.customer = :user " +
+            "LEFT JOIN p.perfumeVolumes pv " +
+            "LEFT JOIN p.perfumeAccords pa " +
+            "LEFT JOIN pa.accord a " +
+            "WHERE (:minPrice IS NULL OR pv.price >= :minPrice) AND " +
+            "(:maxPrice IS NULL OR pv.price <= :maxPrice) AND " +
+            "(:genders IS NULL OR p.gender IN :genders) AND " +
+            "(:accords IS NULL OR a.name IN :accords) AND " +
+            "(:potencies IS NULL OR p.potential IN :potencies) AND " +
+            "(:brands IS NULL OR p.brand IN :brands) AND " +
+            "(:countries IS NULL OR p.country IN :countries)")
+    Page<Perfume> findAllWishPerfumeBySearchOptions(
+            Pageable pageable,
+            @Param("minPrice") Integer minPrice,
+            @Param("maxPrice") Integer maxPrice,
+            @Param("genders") List<GenderType> genders,
+            @Param("accords") List<String> accords,
+            @Param("potencies") List<PotentialType> potencies,
+            @Param("brands") List<BrandType> brands,
+            @Param("countries") List<CountryType> countries,
+            @Param("user") User user
+    );
 }

--- a/src/main/java/com/itsuda/perfume/repository/PostRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.itsuda.perfume.repository;
 
 import com.itsuda.perfume.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -11,4 +14,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Override
     @EntityGraph(attributePaths = {"user"})
     Optional<Post> findById(Long id);
+
+    Page<Post> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/itsuda/perfume/repository/WishPerfumeRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/WishPerfumeRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface WishPerfumeRepository extends JpaRepository<WishPerfume, Long> {
 
     Optional<WishPerfume> findByPerfumeAndCustomer(Perfume perfume, User customer);
+
 }

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -233,6 +233,20 @@ public class OotdService {
     }
 
     @Transactional
+    public void deleteOotdComment(Long userId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
+        if (Optional.ofNullable(comment.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_COMMENT);
+        }
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new RestApiException(ONLY_COMMENT_OWNER_DELETE);
+        }
+
+        commentRepository.delete(comment);
+    }
+
+    @Transactional
     public void sendLikeToOotdComment(Long userId, Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -21,6 +21,7 @@ import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.dto.response.ootd.OotdThumbnailDto;
+import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
 import com.itsuda.perfume.exception.RestApiException;
 import com.itsuda.perfume.repository.CommentRepository;
 import com.itsuda.perfume.repository.OotdCommentNotificationRepository;
@@ -29,6 +30,7 @@ import com.itsuda.perfume.repository.OotdLikeNotificationRepository;
 import com.itsuda.perfume.repository.OotdPerfumeRepository;
 import com.itsuda.perfume.repository.OotdRepository;
 import com.itsuda.perfume.repository.OotdRepository.OotdThumbnailInfo;
+import com.itsuda.perfume.repository.OotdRepository.UserLikeOotdInfo;
 import com.itsuda.perfume.repository.OotdTagRepository;
 import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.TagRepository;
@@ -220,5 +222,26 @@ public class OotdService {
 
         userLikeCommentRepository.save(UserLikeComment.builder().comment(comment).user(user).build());
         comment.increaseLikeCount();
+    }
+
+    public UserLikeOotdsDto getAllUserLikeOotdsByOrderType(int page, int size, OotdOrderType ootdOrderType, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+        Page<UserLikeOotdInfo> userLikeOotdInfos = Page.empty();
+
+        if (ootdOrderType.equals(OotdOrderType.NEWEST_DESCENDING)) {
+            Pageable pageable = PageRequest.of(page, size, Sort.by("created_at").descending());
+            userLikeOotdInfos = ootdRepository.findAllUserLikeByUser(pageable, userId);
+        } else if (ootdOrderType.equals(OotdOrderType.NEWEST_ASCENDING)) {
+            Pageable pageable = PageRequest.of(page, size, Sort.by("created_at").ascending());
+            userLikeOotdInfos = ootdRepository.findAllUserLikeByUser(pageable, userId);
+        } else if (ootdOrderType.equals(OotdOrderType.POPULAR_DESCENDING)) {
+            Pageable pageable = PageRequest.of(page, size, Sort.by("like_count").descending());
+            userLikeOotdInfos = ootdRepository.findAllUserLikeByUser(pageable, userId);
+        } else if (ootdOrderType.equals(OotdOrderType.POPULAR_ASCENDING)) {
+            Pageable pageable = PageRequest.of(page, size, Sort.by("like_count").ascending());
+            userLikeOotdInfos = ootdRepository.findAllUserLikeByUser(pageable, userId);
+        }
+
+        return UserLikeOotdsDto.from(userLikeOotdInfos.getContent(), PageInfoDto.from(userLikeOotdInfos));
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -160,7 +160,7 @@ public class OotdService {
         if (Optional.ofNullable(ootd.getDeletedAt()).isPresent()) {
             throw new RestApiException(DELETED_OOTD);
         }
-        List<Comment> comments = commentRepository.findAllByOotdAndParentCommentIsNull(ootd);
+        List<Comment> comments = commentRepository.findAllByOotdAndParentCommentIsNullAndDeletedAtIsNull(ootd);
 
         return CommentsDto.from(comments);
     }
@@ -249,6 +249,9 @@ public class OotdService {
     @Transactional
     public void sendLikeToOotdComment(Long userId, Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
+        if (Optional.ofNullable(comment.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_COMMENT);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
 
         Optional<UserLikeComment> userLikeComment = userLikeCommentRepository.findByCommentAndUser(comment, user);

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -144,7 +144,9 @@ public class OotdService {
     @Transactional
     public void deleteOotdByOotdId(Long ootdId, Long userId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
-        List<OotdImage> ootdImages = ootd.getOotdImages();
+        if (Optional.ofNullable(ootd.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_OOTD);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         if (!ootd.getUser().getId().equals(user.getId())) {
             throw new RestApiException(ONLY_OOTD_OWNER_DELETE);

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -52,9 +52,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_COMMENT;
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_OOTD;
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_USER;
+import static com.itsuda.perfume.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -131,6 +129,9 @@ public class OotdService {
 
     public OotdDetailDto getOotdDetailByOotdId(Long ootdId, Long userId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
+        if (Optional.ofNullable(ootd.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_OOTD);
+        }
         List<OotdPerfume> ootdPerfumes = ootdPerfumeRepository.findByOotd(ootd);
         boolean isLiked = Optional.ofNullable(userId).map(usId -> {
             User user = userRepository.findById(usId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
@@ -140,8 +141,23 @@ public class OotdService {
         return OotdDetailDto.from(ootd, ootd.getUser(), ootdPerfumes.stream().map(OotdPerfume::getPerfume).toList(), isLiked);
     }
 
+    @Transactional
+    public void deleteOotdByOotdId(Long ootdId, Long userId) {
+        Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
+        List<OotdImage> ootdImages = ootd.getOotdImages();
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+        if (!ootd.getUser().getId().equals(user.getId())) {
+            throw new RestApiException(ONLY_OOTD_OWNER_DELETE);
+        }
+
+        ootdRepository.delete(ootd);
+    }
+
     public CommentsDto getCommentsByOotdId(Long ootdId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
+        if (Optional.ofNullable(ootd.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_OOTD);
+        }
         List<Comment> comments = commentRepository.findAllByOotdAndParentCommentIsNull(ootd);
 
         return CommentsDto.from(comments);
@@ -151,6 +167,9 @@ public class OotdService {
     @Transactional
     public void sendLikeToOotd(Long ootdId, Long userId) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
+        if (Optional.ofNullable(ootd.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_OOTD);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         Optional<UserFcmToken> userFcmToken = userFcmTokenRepository.findByUser(ootd.getUser());
 
@@ -180,6 +199,9 @@ public class OotdService {
     @Transactional
     public OotdCommentDto writeCommentToOotd(Long ootdId, Long userId, Long commentId, String content) {
         Ootd ootd = ootdRepository.findById(ootdId).orElseThrow(() -> new RestApiException(NOT_FOUND_OOTD));
+        if (Optional.ofNullable(ootd.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_OOTD);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         Optional<UserFcmToken> userFcmToken = userFcmTokenRepository.findByUser(ootd.getUser());
         Optional<Comment> parentComment = Optional.ofNullable(commentId).flatMap(commentRepository::findById);

--- a/src/main/java/com/itsuda/perfume/service/PerfumeService.java
+++ b/src/main/java/com/itsuda/perfume/service/PerfumeService.java
@@ -6,10 +6,14 @@ import com.itsuda.perfume.domain.PerfumeDetail;
 import com.itsuda.perfume.domain.PerfumeVolume;
 import com.itsuda.perfume.domain.User;
 import com.itsuda.perfume.domain.WishPerfume;
+import com.itsuda.perfume.domain.type.PerfumeOrderType;
 import com.itsuda.perfume.dto.request.PerfumeRequestDto;
+import com.itsuda.perfume.dto.request.like.WishPerfumeRequestDto;
+import com.itsuda.perfume.dto.response.PageInfoDto;
 import com.itsuda.perfume.dto.response.PerfumeAccordDto;
 import com.itsuda.perfume.dto.response.PerfumeDetailDto;
 import com.itsuda.perfume.dto.response.PerfumeListDto;
+import com.itsuda.perfume.dto.response.like.WishPerfumesDto;
 import com.itsuda.perfume.dto.response.perfume.OotdPerfumeDto;
 import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.exception.ErrorCode;
@@ -24,6 +28,10 @@ import com.itsuda.perfume.repository.WishPerfumeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -108,5 +116,28 @@ public class PerfumeService {
                     perfume.increaseLikeCount();
                 }
         );
+    }
+
+    public WishPerfumesDto getAllWishPerfumes(WishPerfumeRequestDto wishPerfumeRequestDto, int page, int size, PerfumeOrderType perfumeOrderType, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_USER));
+        Pageable pageable = switch (perfumeOrderType) {
+            case REGISTERED_AT_DESCENDING -> PageRequest.of(page, size, Sort.by("registeredAt").descending());
+            case REGISTERED_AT_ASCENDING -> PageRequest.of(page, size, Sort.by("registeredAt").ascending());
+            case POPULAR_DESCENDING -> PageRequest.of(page, size, Sort.by("wishCount").descending());
+            case POPULAR_ASCENDING -> PageRequest.of(page, size, Sort.by("wishCount").ascending());
+            default -> PageRequest.of(page, size, Sort.by("registeredAt").descending());
+        };
+
+        Page<Perfume> wishPerfumes = perfumeRepository.findAllWishPerfumeBySearchOptions(
+                pageable,
+                wishPerfumeRequestDto.getMinPrice(),
+                wishPerfumeRequestDto.getMaxPrice(),
+                wishPerfumeRequestDto.getGenders(),
+                wishPerfumeRequestDto.getAccords(),
+                wishPerfumeRequestDto.getPotentials(),
+                wishPerfumeRequestDto.getBrands(),
+                wishPerfumeRequestDto.getCountries(),
+                user);
+        return WishPerfumesDto.from(wishPerfumes.getContent(), PageInfoDto.from(wishPerfumes));
     }
 }

--- a/src/main/java/com/itsuda/perfume/service/PostService.java
+++ b/src/main/java/com/itsuda/perfume/service/PostService.java
@@ -125,9 +125,26 @@ public class PostService {
 
     public CommentsDto getCommentsByPostId(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUND_POST));
+        if (Optional.ofNullable(post.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_POST);
+        }
         List<Comment> comments = commentRepository.findAllByPostAndParentCommentIsNull(post);
 
         return CommentsDto.from(comments);
+    }
+
+    @Transactional
+    public void deletePostComment(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
+        if (Optional.ofNullable(comment.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_COMMENT);
+        }
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new RestApiException(ONLY_COMMENT_OWNER_DELETE);
+        }
+
+        commentRepository.delete(comment);
     }
 
     // TODO - 추후 처리율 제한과 비동기 처리 예정
@@ -200,6 +217,9 @@ public class PostService {
     @Transactional
     public void sendLikeToPostComment(Long userId, Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(NOT_FOUND_COMMENT));
+        if (Optional.ofNullable(comment.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_COMMENT);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
 
         Optional<UserLikeComment> userLikeComment = userLikeCommentRepository.findByCommentAndUser(comment, user);

--- a/src/main/java/com/itsuda/perfume/service/PostService.java
+++ b/src/main/java/com/itsuda/perfume/service/PostService.java
@@ -20,7 +20,6 @@ import com.itsuda.perfume.dto.response.post.PostDto;
 import com.itsuda.perfume.dto.response.post.PostInfoDto;
 import com.itsuda.perfume.dto.response.post.PostMainDto;
 import com.itsuda.perfume.dto.response.post.UserInfoDto;
-import com.itsuda.perfume.exception.ErrorCode;
 import com.itsuda.perfume.exception.RestApiException;
 import com.itsuda.perfume.repository.CommentRepository;
 import com.itsuda.perfume.repository.PostCommentNotificationRepository;
@@ -43,9 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_COMMENT;
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUND_USER;
-import static com.itsuda.perfume.exception.ErrorCode.NOT_FOUNT_POST;
+import static com.itsuda.perfume.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -71,19 +68,19 @@ public class PostService {
 
         if (postOrderType.equals(PostOrderType.NEWEST_DESCENDING)) {
             Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-            posts = postRepository.findAll(pageable);
+            posts = postRepository.findAllByDeletedAtIsNull(pageable);
             postDtos = posts.stream().map(PostDto::from).toList();
         } else if (postOrderType.equals(PostOrderType.NEWEST_ASCENDING)) {
             Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").ascending());
-            posts = postRepository.findAll(pageable);
+            posts = postRepository.findAllByDeletedAtIsNull(pageable);
             postDtos = posts.stream().map(PostDto::from).toList();
         } else if (postOrderType.equals(PostOrderType.POPULAR_DESCENDING)) {
             Pageable pageable = PageRequest.of(page, size, Sort.by("likeCount").descending());
-            posts = postRepository.findAll(pageable);
+            posts = postRepository.findAllByDeletedAtIsNull(pageable);
             postDtos = posts.stream().map(PostDto::from).toList();
         } else if (postOrderType.equals(PostOrderType.POPULAR_ASCENDING)) {
             Pageable pageable = PageRequest.of(page, size, Sort.by("likeCount").ascending());
-            posts = postRepository.findAll(pageable);
+            posts = postRepository.findAllByDeletedAtIsNull(pageable);
             postDtos = posts.stream().map(PostDto::from).toList();
         }
 
@@ -103,14 +100,31 @@ public class PostService {
     }
 
     public PostDetailDto getPostDetailByPostId(Long postId) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUNT_POST));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUND_POST));
+        if (Optional.ofNullable(post.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_POST);
+        }
         User user = post.getUser();
 
         return new PostDetailDto(PostInfoDto.from(post), UserInfoDto.from(user));
     }
 
+    @Transactional
+    public void deletePostByPostId(Long postId, Long userId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUND_POST));
+        if (Optional.ofNullable(post.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_POST);
+        }
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new RestApiException(ONLY_POST_OWNER_DELETE);
+        }
+
+        postRepository.delete(post);
+    }
+
     public CommentsDto getCommentsByPostId(Long postId) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUNT_POST));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUND_POST));
         List<Comment> comments = commentRepository.findAllByPostAndParentCommentIsNull(post);
 
         return CommentsDto.from(comments);
@@ -119,7 +133,10 @@ public class PostService {
     // TODO - 추후 처리율 제한과 비동기 처리 예정
     @Transactional
     public void sendLikeToPost(Long postId, Long userId) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUNT_POST));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUND_POST));
+        if (Optional.ofNullable(post.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_POST);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         Optional<UserFcmToken> userFcmToken = userFcmTokenRepository.findByUser(post.getUser());
 
@@ -148,7 +165,10 @@ public class PostService {
 
     @Transactional
     public PostCommentDto writeCommentToPost(Long postId, Long userId, Long commentId, String content) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUNT_POST));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(NOT_FOUND_POST));
+        if (Optional.ofNullable(post.getDeletedAt()).isPresent()) {
+            throw new RestApiException(DELETED_POST);
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(NOT_FOUND_USER));
         Optional<UserFcmToken> userFcmToken = userFcmTokenRepository.findByUser(post.getUser());
         Optional<Comment> parentComment = Optional.ofNullable(commentId).flatMap(commentRepository::findById);

--- a/src/test/java/com/itsuda/perfume/controller/LikeControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/LikeControllerTest.java
@@ -1,0 +1,55 @@
+package com.itsuda.perfume.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itsuda.perfume.domain.type.OotdOrderType;
+import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
+import com.itsuda.perfume.service.OotdService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(LikeController.class)
+@WithMockUser
+@ActiveProfiles("test")
+class LikeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OotdService ootdService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("좋아요를 누른 OOTD 목록들을 조회한다.")
+    @Test
+    void getUserLikeOotds() throws Exception {
+        // given
+        UserLikeOotdsDto result = new UserLikeOotdsDto(null, null);
+
+        Mockito.when(ootdService.getAllUserLikeOotdsByOrderType(anyInt(), anyInt(), eq(OotdOrderType.NEWEST_DESCENDING), anyLong()))
+                .thenReturn(result);
+
+        // when // then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/v1/likes/ootds")
+                                .queryParam("order", "NEWEST_DESCENDING")
+                                .queryParam("page", "0")
+                                .queryParam("size", "3")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+
+    }
+}

--- a/src/test/java/com/itsuda/perfume/controller/LikeControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/LikeControllerTest.java
@@ -2,8 +2,11 @@ package com.itsuda.perfume.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itsuda.perfume.domain.type.OotdOrderType;
+import com.itsuda.perfume.domain.type.PerfumeOrderType;
+import com.itsuda.perfume.dto.response.like.WishPerfumesDto;
 import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
 import com.itsuda.perfume.service.OotdService;
+import com.itsuda.perfume.service.PerfumeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -29,6 +32,9 @@ class LikeControllerTest {
     @MockBean
     private OotdService ootdService;
 
+    @MockBean
+    private PerfumeService perfumeService;
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -50,6 +56,25 @@ class LikeControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result").value("1200"));
+    }
 
+    @DisplayName("위시리스트에 담은 향수 목록들을 조회한다.")
+    @Test
+    void getAllWishPerfumes() throws Exception {
+        // given
+        WishPerfumesDto result = new WishPerfumesDto(null, null);
+
+        Mockito.when(perfumeService.getAllWishPerfumes(any(), anyInt(), anyInt(), eq(PerfumeOrderType.REGISTERED_AT_DESCENDING), anyLong()))
+                .thenReturn(result);
+
+        // when // then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/v1/likes/perfumes")
+                                .queryParam("order", "REGISTERED_AT_DESCENDING")
+                                .queryParam("page", "0")
+                                .queryParam("size", "3")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
     }
 }

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -64,7 +64,7 @@ class OotdControllerTest {
         // when // then
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/v1/ootds")
-                                .queryParam("order", "NEWEST")
+                                .queryParam("order", "NEWEST_DESCENDING")
                                 .queryParam("page", "0")
                                 .queryParam("size", "3")
                 )

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -321,7 +321,19 @@ class OotdControllerTest {
                 .andExpect(jsonPath("$.result").value("1200"));
     }
 
-    @DisplayName("자유게시판의 게시글 ID에 달린 댓글을 조회한다.")
+    @DisplayName("OOTD 게시글을 아이디를 기반으로 삭제한다.")
+    @Test
+    void deleteOotdByOotdId() throws Exception {
+        // given
+        Mockito.doNothing().when(ootdService).deleteOotdByOotdId(anyLong(), anyLong());
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/ootds/1").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+    }
+
+    @DisplayName("OOTD에 달린 댓글을 조회한다.")
     @Test
     void getComments() throws Exception {
         // given

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -346,6 +346,18 @@ class OotdControllerTest {
                 .andExpect(jsonPath("$.result").value("1200"));
     }
 
+    @DisplayName("OOTD에 달린 댓글을 삭제한다.")
+    @Test
+    void deleteOotdComment() throws Exception {
+        // given
+        Mockito.doNothing().when(ootdService).deleteOotdComment(anyLong(), anyLong());
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/ootds/1/comments/1").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+    }
+
     @DisplayName("OOTD 게시글에 좋아요를 눌러서 좋아요를 요청한다.")
     @Test
     void sendLikeToOotd() throws Exception {

--- a/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
@@ -139,6 +139,18 @@ class PostControllerTest {
 
     }
 
+    @DisplayName("자유게시판에 게시글 ID에 맞는 게시글을 삭제한다.")
+    @Test
+    void deletePostByPostId() throws Exception {
+        // given
+        Mockito.doNothing().when(postService).deletePostByPostId(anyLong(), anyLong());
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/1").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
+    }
+
     @DisplayName("자유게시판의 게시글 ID에 달린 댓글을 조회한다.")
     @Test
     void getComments() throws Exception {
@@ -177,6 +189,18 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.result").value("1400"))
                 .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.toString()))
                 .andExpect(jsonPath("$.message").value("댓글은 공백이 아닌 1자 이상이 포함되어야 합니다"));
+    }
+
+    @DisplayName("자유게시글의 댓글ID에 맞는 댓글 삭제를 요청한다.")
+    @Test
+    void deletePostCommentByCommentId() throws Exception {
+        // given
+        Mockito.doNothing().when(postService).deletePostComment(anyLong(), anyLong());
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/1/comments/1").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("1200"));
     }
 
     @DisplayName("자유게시글의 댓글에 좋아요를 눌러서 좋아요를 요청한다.")

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -20,6 +20,7 @@ import com.itsuda.perfume.dto.response.ootd.CreatedOotdDto;
 import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
+import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
 import com.itsuda.perfume.repository.CommentRepository;
 import com.itsuda.perfume.repository.OotdCommentNotificationRepository;
 import com.itsuda.perfume.repository.OotdImageRepository;
@@ -482,6 +483,33 @@ class OotdServiceTest {
         // then
         assertThat(comment.getLikeCount()).isEqualTo(originLikeCount - 1);
         assertThat(userLikeCommentRepository.existsByUserAndComment(user, comment)).isFalse();
+    }
+
+    @DisplayName("사용자가 좋아요를 누른 OOTD만 확인할 수 있다.")
+    @Test
+    void getUserLikesOotds() {
+        // given
+        setMockingTime(20);
+        Ootd savedOotd1 = ootdRepository.save(createOotd(1));
+        ootdImageRepository.save(createOotdImage(0, savedOotd1));
+        ootdService.sendLikeToOotd(savedOotd1.getId(), user.getId());
+
+        setMockingTime(30);
+        Ootd savedOotd2 = ootdRepository.save(createOotd(2));
+        ootdImageRepository.save(createOotdImage(0, savedOotd2));
+
+        setMockingTime(0);
+        Ootd savedOotd3 = ootdRepository.save(createOotd(3));
+        ootdImageRepository.save(createOotdImage(0, savedOotd3));
+        ootdService.sendLikeToOotd(savedOotd3.getId(), user.getId());
+
+        // when
+        UserLikeOotdsDto result = ootdService.getAllUserLikeOotdsByOrderType(0, 3, OotdOrderType.NEWEST_DESCENDING, user.getId());
+
+        // then
+        assertThat(result.dataList()).hasSize(2)
+                .extracting("ootdId")
+                .contains(savedOotd1.getId(), savedOotd3.getId());
     }
 
     private void setMockingTime(int minute) {

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -563,7 +563,7 @@ class OotdServiceTest {
                 .contains("삭제된 댓글입니다", 0);
     }
 
-    @DisplayName("댓글의 작성자만 OOTD를 삭제할 수 있다.")
+    @DisplayName("댓글의 작성자만 댓글을 삭제할 수 있다.")
     @Test
     void onlyOwnerCanDeleteComment() {
         // given

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -21,6 +21,8 @@ import com.itsuda.perfume.dto.response.ootd.OotdCommentDto;
 import com.itsuda.perfume.dto.response.ootd.OotdDetailDto;
 import com.itsuda.perfume.dto.response.ootd.OotdMainDto;
 import com.itsuda.perfume.dto.response.ootd.UserLikeOotdsDto;
+import com.itsuda.perfume.exception.ErrorCode;
+import com.itsuda.perfume.exception.RestApiException;
 import com.itsuda.perfume.repository.CommentRepository;
 import com.itsuda.perfume.repository.OotdCommentNotificationRepository;
 import com.itsuda.perfume.repository.OotdImageRepository;
@@ -55,6 +57,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -512,6 +515,35 @@ class OotdServiceTest {
                 .contains(savedOotd1.getId(), savedOotd3.getId());
     }
 
+    @DisplayName("OOTD를 삭제하면 해당 OOTD의 삭제날짜를 확인할 수 있다.")
+    @Test
+    void deleteOotdhasDeletedDate() {
+        // given
+        Ootd savedOotd = ootdRepository.save(createOotd(0));
+
+        // when
+        ootdService.deleteOotdByOotdId(savedOotd.getId(), user.getId());
+        em.flush();
+        em.clear();
+
+        // then
+        Ootd result = ootdRepository.findById(savedOotd.getId()).get();
+        assertThat(result.getDeletedAt()).isNotNull();
+    }
+
+    @DisplayName("OOTD의 작성자만 OOTD를 삭제할 수 있다.")
+    @Test
+    void onlyOwnerCanDeleteOotd() {
+        // given
+        Ootd savedOotd = ootdRepository.save(createOotd(0));
+        User otherUser = userRepository.save(createTestUser(1));
+
+        // when // then
+        assertThatThrownBy(() -> ootdService.deleteOotdByOotdId(savedOotd.getId(), otherUser.getId()))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ONLY_OOTD_OWNER_DELETE);
+    }
+
     private void setMockingTime(int minute) {
         given(dateTimeProvider.getNow())
                 .willReturn(Optional.of(
@@ -548,6 +580,22 @@ class OotdServiceTest {
                 .role(ERole.USER)
                 .serialId("123")
                 .username("test")
+                .build();
+        user.updateBirthDate("2000-05-02");
+        return user;
+    }
+
+    private static User createTestUser(int number) {
+        User user = User.builder()
+                .email(number + "test@test.com")
+                .gender(GenderType.MALE)
+                .imageUrl(number + "test url")
+                .nickname(number + "test nickname")
+                .presentation(number + "test")
+                .provider(EProvider.GOOGLE)
+                .role(ERole.USER)
+                .serialId(number + "123")
+                .username(number + "test")
                 .build();
         user.updateBirthDate("2000-05-02");
         return user;

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -517,7 +517,7 @@ class OotdServiceTest {
 
     @DisplayName("OOTD를 삭제하면 해당 OOTD의 삭제날짜를 확인할 수 있다.")
     @Test
-    void deletedOotdJasDeletedDate() {
+    void deletedOotdHasDeletedDate() {
         // given
         Ootd savedOotd = ootdRepository.save(createOotd(0));
 

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -517,7 +517,7 @@ class OotdServiceTest {
 
     @DisplayName("OOTD를 삭제하면 해당 OOTD의 삭제날짜를 확인할 수 있다.")
     @Test
-    void deleteOotdhasDeletedDate() {
+    void deletedOotdJasDeletedDate() {
         // given
         Ootd savedOotd = ootdRepository.save(createOotd(0));
 
@@ -525,9 +525,9 @@ class OotdServiceTest {
         ootdService.deleteOotdByOotdId(savedOotd.getId(), user.getId());
         em.flush();
         em.clear();
+        Ootd result = ootdRepository.findById(savedOotd.getId()).get();
 
         // then
-        Ootd result = ootdRepository.findById(savedOotd.getId()).get();
         assertThat(result.getDeletedAt()).isNotNull();
     }
 
@@ -542,6 +542,39 @@ class OotdServiceTest {
         assertThatThrownBy(() -> ootdService.deleteOotdByOotdId(savedOotd.getId(), otherUser.getId()))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.ONLY_OOTD_OWNER_DELETE);
+    }
+
+    @DisplayName("댓글을 삭제하면 해당 댓글의 삭제날짜를 확인할 수 있고 메시지가 삭제된 메시지입니다라고 바뀌며 좋아요는 0이 된다.")
+    @Test
+    void deletedCommentHasDeletedDateAndMessageAndLikeCountIsChanged() {
+        // given
+        Ootd ootd = ootdRepository.save(createOotd(0));
+        Comment comment = commentRepository.save(createComment(0, null, ootd, user));
+
+        // when
+        ootdService.deleteOotdComment(user.getId(), comment.getId());
+        em.flush();
+        em.clear();
+        Comment deletedComment = commentRepository.findById(comment.getId()).get();
+
+        // then
+        assertThat(deletedComment.getDeletedAt()).isNotNull();
+        assertThat(deletedComment).extracting("content", "likeCount")
+                .contains("삭제된 댓글입니다", 0);
+    }
+
+    @DisplayName("댓글의 작성자만 OOTD를 삭제할 수 있다.")
+    @Test
+    void onlyOwnerCanDeleteComment() {
+        // given
+        Ootd ootd = ootdRepository.save(createOotd(0));
+        Comment comment = commentRepository.save(createComment(0, null, ootd, user));
+        User otherUser = userRepository.save(createTestUser(1));
+
+        // when // then
+        assertThatThrownBy(() -> ootdService.deleteOotdComment(otherUser.getId(), comment.getId()))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ONLY_COMMENT_OWNER_DELETE);
     }
 
     private void setMockingTime(int minute) {

--- a/src/test/java/com/itsuda/perfume/service/PerfumeServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PerfumeServiceTest.java
@@ -8,7 +8,11 @@ import com.itsuda.perfume.domain.type.CountryType;
 import com.itsuda.perfume.domain.type.EProvider;
 import com.itsuda.perfume.domain.type.ERole;
 import com.itsuda.perfume.domain.type.GenderType;
+import com.itsuda.perfume.domain.type.PerfumeOrderType;
 import com.itsuda.perfume.domain.type.PotentialType;
+import com.itsuda.perfume.dto.request.like.WishPerfumeRequestDto;
+import com.itsuda.perfume.dto.response.like.WishPerfumeDto;
+import com.itsuda.perfume.dto.response.like.WishPerfumesDto;
 import com.itsuda.perfume.dto.response.perfume.OotdPerfumesDto;
 import com.itsuda.perfume.repository.PerfumeRepository;
 import com.itsuda.perfume.repository.UserRepository;
@@ -119,6 +123,29 @@ class PerfumeServiceTest {
         // then
         assertThat(wishPerfume).isPresent();
         assertThat(wishPerfume.get().getPerfume().getWishCount()).isEqualTo(originWishCount - 1);
+    }
+
+    @DisplayName("사용자가 좋아요를 누른 향수 목록을 확인할 수 있다.")
+    @Test
+    void getAllWishPerfumes() {
+        // given
+        Perfume perfume1 = perfumeRepository.save(createPerfume("test1"));
+        Perfume perfume2 = perfumeRepository.save(createPerfume("test2"));
+        Perfume perfume3 = perfumeRepository.save(createPerfume("test3"));
+        User user = userRepository.save(createTestUser());
+        perfumeService.sendWishToPerfume(perfume1.getId(), user.getId());
+        perfumeService.sendWishToPerfume(perfume3.getId(), user.getId());
+        WishPerfumeRequestDto wishPerfumeRequestDto = new WishPerfumeRequestDto(null, null, null, null, null, null, null);
+
+        // when
+        WishPerfumesDto wishPerfumes = perfumeService.getAllWishPerfumes(
+                wishPerfumeRequestDto, 0, 3, PerfumeOrderType.REGISTERED_AT_DESCENDING, user.getId());
+
+        // then
+        assertThat(wishPerfumes.dataList()).size().isEqualTo(2);
+        assertThat(wishPerfumes.dataList())
+                .extracting("name")
+                .contains("test1 perfume", "test3 perfume");
     }
 
     private static Perfume createPerfume(String name) {

--- a/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
@@ -271,7 +271,36 @@ class PostServiceTest {
         // then
         assertThatThrownBy(() -> postService.getPostDetailByPostId(savedPost.getId() + 1))
                 .isInstanceOf(RestApiException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.NOT_FOUNT_POST);
+                .extracting("errorCode").isEqualTo(ErrorCode.NOT_FOUND_POST);
+    }
+
+    @DisplayName("자유게시글을 삭제하면 해당 자유게시글의 삭제날짜를 확인할 수 있다.")
+    @Test
+    void deletePostHasDeletedDate() {
+        // given
+        Post post = postRepository.save(createPost(1, user));
+
+        // when
+        postService.deletePostByPostId(post.getId(), user.getId());
+        em.flush();
+        em.clear();
+        Post deletedPost = postRepository.findById(post.getId()).get();
+
+        // then
+        assertThat(deletedPost.getDeletedAt()).isNotNull();
+    }
+
+    @DisplayName("자유게시글의 작성자만 자유게시글을 삭제할 수 있다.")
+    @Test
+    void onlyOwnerCanDeletePost() {
+        // given
+        Post post = postRepository.save(createPost(1, user));
+        User otherUser = userRepository.save(createTestUser(1));
+
+        // when // then
+        assertThatThrownBy(() -> postService.deletePostByPostId(post.getId(), otherUser.getId()))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ONLY_POST_OWNER_DELETE);
     }
 
     @DisplayName("자유게시판의 게시글에 달린 댓글들을 모두 조회한다.")
@@ -470,6 +499,22 @@ class PostServiceTest {
                 .role(ERole.USER)
                 .serialId("123")
                 .username("test")
+                .build();
+        user.updateBirthDate("2000-05-02");
+        return user;
+    }
+
+    private static User createTestUser(int number) {
+        User user = User.builder()
+                .email(number + "test@test.com")
+                .gender(GenderType.MALE)
+                .imageUrl(number + "test url")
+                .nickname(number + "test nickname")
+                .presentation(number + "test")
+                .provider(EProvider.GOOGLE)
+                .role(ERole.USER)
+                .serialId(number + "123")
+                .username(number + "test")
                 .build();
         user.updateBirthDate("2000-05-02");
         return user;

--- a/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
@@ -1,6 +1,7 @@
 package com.itsuda.perfume.service;
 
 import com.itsuda.perfume.domain.Comment;
+import com.itsuda.perfume.domain.Ootd;
 import com.itsuda.perfume.domain.Post;
 import com.itsuda.perfume.domain.PostCommentNotification;
 import com.itsuda.perfume.domain.User;
@@ -446,6 +447,39 @@ class PostServiceTest {
         // then
         assertThat(notifications).hasSize(1);
         assertThat(notifications).extracting("commentWriter").containsExactly(user);
+    }
+
+    @DisplayName("댓글을 삭제하면 해당 댓글의 삭제날짜를 확인할 수 있고 메시지가 삭제된 메시지입니다라고 바뀌며 좋아요는 0이 된다.")
+    @Test
+    void deletedCommentHasDeletedDateAndMessageAndLikeCountIsChanged() {
+        // given
+        Post post = postRepository.save(createPost(0, user));
+        Comment comment = commentRepository.save(createComment(0, null, post, user));
+
+        // when
+        postService.deletePostComment(user.getId(), comment.getId());
+        em.flush();
+        em.clear();
+        Comment deletedComment = commentRepository.findById(comment.getId()).get();
+
+        // then
+        assertThat(deletedComment.getDeletedAt()).isNotNull();
+        assertThat(deletedComment).extracting("content", "likeCount")
+                .contains("삭제된 댓글입니다", 0);
+    }
+
+    @DisplayName("댓글의 작성자만 댓글을 삭제할 수 있다.")
+    @Test
+    void onlyOwnerCanDeleteComment() {
+        // given
+        Post post = postRepository.save(createPost(0, user));
+        Comment comment = commentRepository.save(createComment(0, null, post, user));
+        User otherUser = userRepository.save(createTestUser(1));
+
+        // when // then
+        assertThatThrownBy(() -> postService.deletePostComment(otherUser.getId(), comment.getId()))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ONLY_COMMENT_OWNER_DELETE);
     }
 
     @DisplayName("댓글에 좋아요를 요청하면 좋아요가 1만큼 오르고 사용자는 댓글에 좋아요를 누른 것을 확인할 수 있다.")


### PR DESCRIPTION
## ✨ Description
- 향수 위시리스트 모아보기 기능과 OOTD 좋아요 리스트를 조회하는 기능을 구현했습니다.
- OOTD와 자유게시글을 삭제하는 기능을 구현했습니다. 삭제가 일어나는 경우 deletedAt의 nullable 여부로 삭제를 판단하며, 삭제의 경우 연관 관계 문제 때문에 일단 Soft Delete로 구현했으나 추후 Hard Delete로 변경할 예정입니다.
- 댓글 삭제도 마찬가지로 앞선 내용과 같이 구현했습니다. 추가적으로 에브리타임과 같이 댓글의 내용이 "삭제된 댓글입니다"로 변경되면서 좋아요를 0으로 업데이트하는 것으로 구현했습니다.
- 알림 모아보기를 구현한 줄 알았는데 구현을 안해놨어서 다음 PR에 구현해서 올리도록 하겠습니다~

---

## 🔗 Related Issue
- Closes #50 
