### PR TITLE
Feat: 소셜측 상세정보 추가 및 검색 기능 추가

### DIFF
--- a/src/main/java/com/itsuda/perfume/controller/LikeController.java
+++ b/src/main/java/com/itsuda/perfume/controller/LikeController.java
@@ -30,10 +30,10 @@ public class LikeController {
     @Operation(summary = "OOTD 좋아요 모아보기", description = "좋아요를 누른 OOTD들을 순서에 맞게 조회합니다.")
     @GetMapping("/ootds")
     public ResponseDto<UserLikeOotdsDto> getUserLikeOotds(
-            @UserId Long userId,
+            @UserId Long userId, @RequestParam int page, @RequestParam int size,
             @RequestParam(required = false, defaultValue = "NEWEST_DESCENDING") OotdOrderType order,
-            @RequestParam int page, @RequestParam int size) {
-        return new ResponseDto<>(ootdService.getAllUserLikeOotdsByOrderType(page, size, order, 0L));
+            @RequestParam(required = false) String keyword) {
+        return new ResponseDto<>(ootdService.getAllUserLikeOotdsByOrderType(page, size, keyword, order, 0L));
     }
 
     @Operation(summary = "향수 위시 모아보기", description = "위시리스트에 담은 향수들을 조회합니다.")

--- a/src/main/java/com/itsuda/perfume/controller/OotdController.java
+++ b/src/main/java/com/itsuda/perfume/controller/OotdController.java
@@ -43,9 +43,10 @@ public class OotdController {
     @GetMapping
     public ResponseDto<OotdMainDto> getOotdThumbnails(
             @UserId(required = false) Long userId, @RequestParam int page, @RequestParam int size,
+            @RequestParam(required = false, defaultValue = "") String keyword,
             @RequestParam(required = false, defaultValue = "NEWEST_DESCENDING") OotdOrderType order
     ) {
-        return new ResponseDto<>(ootdService.getOotdThumbnailsByOrderType(page, size, order, userId));
+        return new ResponseDto<>(ootdService.getOotdThumbnailsByOrderType(page, size, keyword, order, userId));
     }
 
     @Operation(summary = "OOTD 작성", description = "OOTD에 게시글을 작성합니다.")

--- a/src/main/java/com/itsuda/perfume/controller/PostController.java
+++ b/src/main/java/com/itsuda/perfume/controller/PostController.java
@@ -35,9 +35,10 @@ public class PostController {
     @Operation(summary = "자유게시글 목록 조회", description = "자유게시판에 올라온 게시글들을 조회합니다.")
     @GetMapping
     public ResponseDto<PostMainDto> getPosts(
-            @RequestParam(required = false, defaultValue = "NEWEST") PostOrderType order,
-            @RequestParam int page, @RequestParam int size) {
-        return new ResponseDto<>(postService.getPostsByOrderType(page, size, order));
+            @RequestParam int page, @RequestParam int size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false, defaultValue = "NEWEST") PostOrderType order) {
+        return new ResponseDto<>(postService.getPostsByOrderType(page, size, keyword, order));
     }
 
     @Operation(summary = "자유게시글 작성", description = "자유게시판에 게시글을 작성합니다.")

--- a/src/main/java/com/itsuda/perfume/dto/response/ootd/UserInfoDto.java
+++ b/src/main/java/com/itsuda/perfume/dto/response/ootd/UserInfoDto.java
@@ -3,16 +3,20 @@ package com.itsuda.perfume.dto.response.ootd;
 import com.itsuda.perfume.domain.User;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 public record UserInfoDto(
+        Long userId,
+        String profileImageUrl,
+        String nickname,
         String gender,
         int age
 ) {
 
     public static UserInfoDto from(User user) {
         return new UserInfoDto(
+                user.getId(),
+                user.getImageUrl(),
+                user.getNickname(),
                 user.getGender().getDescription(),
                 user.getAge(LocalDate.now())
         );

--- a/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/OotdRepository.java
@@ -20,16 +20,16 @@ public interface OotdRepository extends JpaRepository<Ootd, Long> {
             "CASE WHEN ulo.id IS NULL THEN FALSE ELSE TRUE END AS isLiked FROM ootd o " +
             "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id " +
             "LEFT JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id " +
-            "WHERE o.deleted_at IS NULL",
+            "WHERE o.deleted_at IS NULL AND o.content LIKE %:keyword%",
             nativeQuery = true)
-    Page<OotdThumbnailInfo> findAllIncludingUserLiked(Pageable pageable, Long userId);
+    Page<OotdThumbnailInfo> findAllByKeywordIncludingUserLiked(Pageable pageable, Long userId, String keyword);
 
     @Query(value = "SELECT o.id AS ootdId, oi.save_name AS ootdImageUrl FROM ootd o " +
             "INNER JOIN user_like_ootd ulo ON :userId IS NOT NULL AND ulo.user_id = :userId AND ulo.ootd_id = o.id " +
             "LEFT JOIN ootd_image oi ON oi.sequence = 0 AND oi.ootd_id = o.id " +
-            "WHERE o.deleted_at IS NULL",
+            "WHERE o.deleted_at IS NULL AND o.content LIKE %:keyword%",
             nativeQuery = true)
-    Page<UserLikeOotdInfo> findAllUserLikeByUser(Pageable pageable, Long userId);
+    Page<UserLikeOotdInfo> findAllByKeywordContainsAndUserLikeByUser(Pageable pageable, Long userId, String keyword);
 
     interface OotdThumbnailInfo {
         Long getOotdId();

--- a/src/main/java/com/itsuda/perfume/repository/PostRepository.java
+++ b/src/main/java/com/itsuda/perfume/repository/PostRepository.java
@@ -15,5 +15,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = {"user"})
     Optional<Post> findById(Long id);
 
-    Page<Post> findAllByDeletedAtIsNull(Pageable pageable);
+    Page<Post> findAllByDeletedAtIsNullAndTitleContains(Pageable pageable, String keyword);
 }

--- a/src/main/java/com/itsuda/perfume/service/OotdService.java
+++ b/src/main/java/com/itsuda/perfume/service/OotdService.java
@@ -50,7 +50,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
@@ -83,7 +82,7 @@ public class OotdService {
     @Value("${cloud.aws.s3.save-path.ootd-image}")
     private String OOTD_IMAGE_SAVE_PATH;
 
-    public OotdMainDto getOotdThumbnailsByOrderType(int page, int size, OotdOrderType ootdOrderType, Long userId) {
+    public OotdMainDto getOotdThumbnailsByOrderType(int page, int size, String keyword, OotdOrderType ootdOrderType, Long userId) {
         Pageable pageable = PageRequest.of(page, size, switch (ootdOrderType) {
             case NEWEST_DESCENDING -> Sort.by("created_at").descending();
             case NEWEST_ASCENDING -> Sort.by("created_at").ascending();
@@ -91,7 +90,7 @@ public class OotdService {
             case POPULAR_ASCENDING -> Sort.by("like_count").ascending();
         });
 
-        return OotdMainDto.from(ootdRepository.findAllIncludingUserLiked(pageable, userId));
+        return OotdMainDto.from(ootdRepository.findAllByKeywordIncludingUserLiked(pageable, userId, keyword));
     }
 
     @Transactional
@@ -218,7 +217,7 @@ public class OotdService {
         comment.increaseLikeCount();
     }
 
-    public UserLikeOotdsDto getAllUserLikeOotdsByOrderType(int page, int size, OotdOrderType ootdOrderType, Long userId) {
+    public UserLikeOotdsDto getAllUserLikeOotdsByOrderType(int page, int size, String keyword, OotdOrderType ootdOrderType, Long userId) {
         if (!userRepository.existsById(userId)) {
             throw new RestApiException(NOT_FOUND_USER);
         }
@@ -230,7 +229,7 @@ public class OotdService {
                     case POPULAR_DESCENDING -> Sort.by("like_count").descending();
                     case POPULAR_ASCENDING -> Sort.by("like_count").ascending();
                 });
-        Page<UserLikeOotdInfo> userLikeOotdInfos = ootdRepository.findAllUserLikeByUser(pageable, userId);
+        Page<UserLikeOotdInfo> userLikeOotdInfos = ootdRepository.findAllByKeywordContainsAndUserLikeByUser(pageable, userId, keyword);
         return UserLikeOotdsDto.from(userLikeOotdInfos.getContent(), PageInfoDto.from(userLikeOotdInfos));
     }
 

--- a/src/main/java/com/itsuda/perfume/service/PostService.java
+++ b/src/main/java/com/itsuda/perfume/service/PostService.java
@@ -57,7 +57,7 @@ public class PostService {
     private final UserRepository userRepository;
     private final FcmService fcmService;
 
-    public PostMainDto getPostsByOrderType(int page, int size, PostOrderType postOrderType) {
+    public PostMainDto getPostsByOrderType(int page, int size, String keyword, PostOrderType postOrderType) {
         Pageable pageable = PageRequest.of(page, size, switch (postOrderType) {
             case NEWEST_DESCENDING -> Sort.by("createdAt").descending();
             case NEWEST_ASCENDING -> Sort.by("createdAt").ascending();
@@ -65,7 +65,7 @@ public class PostService {
             case POPULAR_ASCENDING -> Sort.by("likeCount").ascending();
         });
 
-        return PostMainDto.from(postRepository.findAllByDeletedAtIsNull(pageable));
+        return PostMainDto.from(postRepository.findAllByDeletedAtIsNullAndTitleContains(pageable, keyword));
     }
 
     @Transactional

--- a/src/test/java/com/itsuda/perfume/controller/LikeControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/LikeControllerTest.java
@@ -44,7 +44,7 @@ class LikeControllerTest {
         // given
         UserLikeOotdsDto result = new UserLikeOotdsDto(null, null);
 
-        Mockito.when(ootdService.getAllUserLikeOotdsByOrderType(anyInt(), anyInt(), eq(OotdOrderType.NEWEST_DESCENDING), anyLong()))
+        Mockito.when(ootdService.getAllUserLikeOotdsByOrderType(anyInt(), anyInt(), anyString(), eq(OotdOrderType.NEWEST_DESCENDING), anyLong()))
                 .thenReturn(result);
 
         // when // then

--- a/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/OotdControllerTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -58,7 +59,7 @@ class OotdControllerTest {
         // given
         OotdMainDto result = new OotdMainDto(null, null);
 
-        Mockito.when(ootdService.getOotdThumbnailsByOrderType(anyInt(), anyInt(), eq(OotdOrderType.NEWEST_DESCENDING), anyLong()))
+        Mockito.when(ootdService.getOotdThumbnailsByOrderType(anyInt(), anyInt(), anyString(), eq(OotdOrderType.NEWEST_DESCENDING), anyLong()))
                 .thenReturn(result);
 
         // when // then

--- a/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
+++ b/src/test/java/com/itsuda/perfume/controller/PostControllerTest.java
@@ -49,7 +49,7 @@ class PostControllerTest {
     void getPosts() throws Exception {
         // given
         PostMainDto result = new PostMainDto(null, null);
-        Mockito.when(postService.getPostsByOrderType(anyInt(), anyInt(), any(PostOrderType.class)))
+        Mockito.when(postService.getPostsByOrderType(anyInt(), anyInt(), "", any(PostOrderType.class)))
                 .thenReturn(result);
 
         // when // then

--- a/src/test/java/com/itsuda/perfume/repository/OotdRepositoryTest.java
+++ b/src/test/java/com/itsuda/perfume/repository/OotdRepositoryTest.java
@@ -103,7 +103,7 @@ class OotdRepositoryTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 3, Sort.by("created_at").descending());
-        Page<OotdThumbnailInfo> ootdThumbnailInfos = ootdRepository.findAllIncludingUserLiked(pageable, user.getId());
+        Page<OotdThumbnailInfo> ootdThumbnailInfos = ootdRepository.findAllByKeywordIncludingUserLiked(pageable, user.getId(), "");
 
         // then
         assertThat(ootdThumbnailInfos.getContent()).hasSize(3)
@@ -133,7 +133,7 @@ class OotdRepositoryTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 3, Sort.by("created_at").descending());
-        Page<OotdThumbnailInfo> ootdThumbnailInfos = ootdRepository.findAllIncludingUserLiked(pageable, user.getId());
+        Page<OotdThumbnailInfo> ootdThumbnailInfos = ootdRepository.findAllByKeywordIncludingUserLiked(pageable, user.getId(), "");
 
         // then
         assertThat(ootdThumbnailInfos.getContent()).hasSize(3)

--- a/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/OotdServiceTest.java
@@ -214,7 +214,7 @@ class OotdServiceTest {
         ootdImageRepository.save(createOotdImage(0, savedOotd3));
 
         // when
-        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, OotdOrderType.NEWEST_DESCENDING, user.getId());
+        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, "", OotdOrderType.NEWEST_DESCENDING, user.getId());
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -239,7 +239,7 @@ class OotdServiceTest {
         ootdImageRepository.save(createOotdImage(0, savedOotd3));
 
         // when
-        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, OotdOrderType.NEWEST_ASCENDING, user.getId());
+        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, "", OotdOrderType.NEWEST_ASCENDING, user.getId());
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -267,7 +267,7 @@ class OotdServiceTest {
         ootdImageRepository.save(createOotdImage(0, savedOotd3));
 
         // when
-        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, OotdOrderType.POPULAR_DESCENDING, user.getId());
+        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, "", OotdOrderType.POPULAR_DESCENDING, user.getId());
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -295,7 +295,7 @@ class OotdServiceTest {
         ootdImageRepository.save(createOotdImage(0, savedOotd3));
 
         // when
-        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, OotdOrderType.POPULAR_ASCENDING, user.getId());
+        OotdMainDto result = ootdService.getOotdThumbnailsByOrderType(0, 3, "", OotdOrderType.POPULAR_ASCENDING, user.getId());
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -595,7 +595,7 @@ class OotdServiceTest {
         ootdService.sendLikeToOotd(savedOotd3.getId(), user.getId());
 
         // when
-        UserLikeOotdsDto result = ootdService.getAllUserLikeOotdsByOrderType(0, 3, OotdOrderType.NEWEST_DESCENDING, user.getId());
+        UserLikeOotdsDto result = ootdService.getAllUserLikeOotdsByOrderType(0, 3, "", OotdOrderType.NEWEST_DESCENDING, user.getId());
 
         // then
         assertThat(result.dataList()).hasSize(2)

--- a/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
+++ b/src/test/java/com/itsuda/perfume/service/PostServiceTest.java
@@ -129,7 +129,7 @@ class PostServiceTest {
         Post post3 = postRepository.save(createPost(3, user));
 
         // when
-        PostMainDto result = postService.getPostsByOrderType(0, 3, PostOrderType.NEWEST_DESCENDING);
+        PostMainDto result = postService.getPostsByOrderType(0, 3, "", PostOrderType.NEWEST_DESCENDING);
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -151,7 +151,7 @@ class PostServiceTest {
         Post post3 = postRepository.save(createPost(3, user));
 
         // when
-        PostMainDto result = postService.getPostsByOrderType(0, 3, PostOrderType.NEWEST_ASCENDING);
+        PostMainDto result = postService.getPostsByOrderType(0, 3, "", PostOrderType.NEWEST_ASCENDING);
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -179,7 +179,7 @@ class PostServiceTest {
         post3.increaseLikeCount();
 
         // when
-        PostMainDto result = postService.getPostsByOrderType(0, 3, PostOrderType.POPULAR_DESCENDING);
+        PostMainDto result = postService.getPostsByOrderType(0, 3, "", PostOrderType.POPULAR_DESCENDING);
 
         // then
         assertThat(result.dataList()).hasSize(3)
@@ -207,7 +207,7 @@ class PostServiceTest {
         post3.increaseLikeCount();
 
         // when
-        PostMainDto result = postService.getPostsByOrderType(0, 3, PostOrderType.POPULAR_ASCENDING);
+        PostMainDto result = postService.getPostsByOrderType(0, 3, "", PostOrderType.POPULAR_ASCENDING);
 
         // then
         assertThat(result.dataList()).hasSize(3)


### PR DESCRIPTION
## ✨ Description
- OOTD 상세보기에서 누락된 사용자 아이디와 프로필 이미지, 닉네임 정보 추가
- OOTD, 자유게시판, 좋아요한 OOTD를 검색할 수 있도록 keyword 쿼리파라미터 추가(OOTD는 내용 기준, 자유게시판은 제목 기준으로 검색)

---

## 🔗 Related Issue
- Closes #63 
